### PR TITLE
Virtualize debt schedule table using react-window

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "json2csv": "^6.0.0",
+    "json2csv": "^6.0.0-alpha.2",
     "jspdf": "^2.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
-    "recharts": "^2.12.7"
+    "recharts": "^2.12.7",
+    "react-window": "^1.8.8"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",

--- a/src/components/DebtScheduleViewer.tsx
+++ b/src/components/DebtScheduleViewer.tsx
@@ -1,16 +1,49 @@
 import React, { useMemo } from 'react';
-import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid, Legend } from 'recharts';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  Legend
+} from 'recharts';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { PlanResult } from '../logic/debt';
 
 const fmtMoney = (n: number) => `$${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 
-export default function DebtScheduleViewer({ plan }:{ plan: PlanResult }) {
-  const chartData = useMemo(() => plan.schedule.map(s => ({
-    month: s.month,
-    interest: s.interest,
-    principal: s.principal,
-    payment: s.payment
-  })), [plan.schedule]);
+export default function DebtScheduleViewer({ plan }: { plan: PlanResult }) {
+  const chartData = useMemo(
+    () =>
+      plan.schedule.map((s) => ({
+        month: s.month,
+        interest: s.interest,
+        principal: s.principal,
+        payment: s.payment
+      })),
+    [plan.schedule]
+  );
+
+  const ROW_HEIGHT = 40;
+
+  const TableRow = ({ index, style }: ListChildComponentProps) => {
+    const s = plan.schedule[index];
+    return (
+      <tr key={s.month} style={style} className="border-b border-gray-100 dark:border-gray-800">
+        <td className="py-2 pr-4">{s.month}</td>
+        <td className="py-2 pr-4">${s.payment.toFixed(2)}</td>
+        <td className="py-2 pr-4 text-green-600">${s.principal.toFixed(2)}</td>
+        <td className="py-2 pr-4 text-red-500">${s.interest.toFixed(2)}</td>
+        <td className="py-2 pr-4">{(s.unlockedBadges || []).join(', ')}</td>
+      </tr>
+    );
+  };
+
+  const TBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+    (props, ref) => <tbody ref={ref} {...props} />
+  );
 
   return (
     <div className="space-y-4">
@@ -32,30 +65,26 @@ export default function DebtScheduleViewer({ plan }:{ plan: PlanResult }) {
       </div>
       <div className="p-4 bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
         <div className="font-medium mb-2">Amortization Table</div>
-        <div className="overflow-auto">
-          <table className="min-w-full text-sm">
-            <thead>
-              <tr className="text-left border-b border-gray-200 dark:border-gray-700">
-                <th className="py-2 pr-4">Month</th>
-                <th className="py-2 pr-4">Payment</th>
-                <th className="py-2 pr-4">Principal</th>
-                <th className="py-2 pr-4">Interest</th>
-                <th className="py-2 pr-4">Badges Unlocked</th>
-              </tr>
-            </thead>
-            <tbody>
-              {plan.schedule.map(s => (
-                <tr key={s.month} className="border-b border-gray-100 dark:border-gray-800">
-                  <td className="py-2 pr-4">{s.month}</td>
-                  <td className="py-2 pr-4">${s.payment.toFixed(2)}</td>
-                  <td className="py-2 pr-4 text-green-600">${s.principal.toFixed(2)}</td>
-                  <td className="py-2 pr-4 text-red-500">${s.interest.toFixed(2)}</td>
-                  <td className="py-2 pr-4">{(s.unlockedBadges||[]).join(', ')}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left border-b border-gray-200 dark:border-gray-700">
+              <th className="py-2 pr-4">Month</th>
+              <th className="py-2 pr-4">Payment</th>
+              <th className="py-2 pr-4">Principal</th>
+              <th className="py-2 pr-4">Interest</th>
+              <th className="py-2 pr-4">Badges Unlocked</th>
+            </tr>
+          </thead>
+          <FixedSizeList
+            height={Math.min(400, plan.schedule.length * ROW_HEIGHT)}
+            itemCount={plan.schedule.length}
+            itemSize={ROW_HEIGHT}
+            width="100%"
+            outerElementType={TBody}
+          >
+            {TableRow}
+          </FixedSizeList>
+        </table>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add react-window to dependencies
- virtualize DebtScheduleViewer amortization table for smoother scrolling
- update json2csv to latest available prerelease

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae532017a48331aa098a2658c1a53b