### PR TITLE
refactor: preparse hotkey bindings

### DIFF
--- a/src/hooks/useHotkeys.ts
+++ b/src/hooks/useHotkeys.ts
@@ -1,25 +1,44 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
+
+interface ParsedBinding {
+  key: string;
+  ctrl: boolean;
+  meta: boolean;
+  shift: boolean;
+  fn: (e: KeyboardEvent) => void;
+}
 
 export default function useHotkeys(bindings: Array<[string, (e: KeyboardEvent) => void]>) {
+  const parsedBindings = useMemo<ParsedBinding[]>(
+    () =>
+      bindings.map(([combo, fn]) => {
+        const parts = combo.toLowerCase().split('+').map((s) => s.trim());
+        return {
+          key: parts[parts.length - 1],
+          ctrl: parts.includes('ctrl'),
+          meta: parts.includes('meta'),
+          shift: parts.includes('shift'),
+          fn,
+        };
+      }),
+    [bindings]
+  );
+
   useEffect(() => {
     function handler(e: KeyboardEvent) {
-      for (const [combo, fn] of bindings) {
-        const parts = combo.toLowerCase().split('+').map((s) => s.trim());
-        const needMeta = parts.includes('meta');
-        const needCtrl = parts.includes('ctrl');
-        const needShift = parts.includes('shift');
-        const key = parts[parts.length - 1];
-        if ((needMeta ? e.metaKey : true) &&
-            (needCtrl ? e.ctrlKey : true) &&
-            (needShift ? e.shiftKey : true) &&
-            e.key.toLowerCase() === key) {
+      for (const { key, ctrl, meta, shift, fn } of parsedBindings) {
+        if (meta && !e.metaKey) continue;
+        if (ctrl && !e.ctrlKey) continue;
+        if (shift && !e.shiftKey) continue;
+        if (e.key.toLowerCase() === key) {
           e.preventDefault();
           fn(e);
           return;
         }
       }
     }
+
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [bindings]);
+  }, [parsedBindings]);
 }


### PR DESCRIPTION
## Summary
- pre-parse hotkey combos into structured objects
- update keydown handler to use pre-parsed bindings

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*


------
https://chatgpt.com/codex/tasks/task_e_68ae531ea720833182416dcb7630557f