### PR TITLE
feat: memoize budget handlers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import Button from './components/Button';
 import ThemeToggle from './components/ThemeToggle';
 import CommandPalette from './components/CommandPalette';
@@ -85,6 +85,18 @@ export default function App(){
     ['shift+g', ()=> setTab('dashboard')],
   ]);
 
+  const handleAddBudget = useCallback((b: Budget) => {
+    setBudgets(prev => [...prev, b]);
+  }, []);
+
+  const handleUpdateBudget = useCallback((b: Budget) => {
+    setBudgets(prev => prev.map(x => x.id === b.id ? b : x));
+  }, []);
+
+  const handleDeleteBudget = useCallback((id: string) => {
+    setBudgets(prev => prev.filter(x => x.id !== id));
+  }, []);
+
   function handleExport(kind: 'json'|'csv'|'pdf') {
     const payload = { budgets, recurring, goals, debts, bnpl: SEEDED.bnpl };
     if (kind === 'json') exportJSON('chatpay-data.json', payload);
@@ -166,9 +178,9 @@ export default function App(){
         {tab === 'budgets' && (
           <BudgetTracker
             budgets={budgets}
-            onAdd={b=>setBudgets(prev=>[...prev,b])}
-            onUpdate={b=>setBudgets(prev=>prev.map(x=>x.id===b.id?b:x))}
-            onDelete={id=>setBudgets(prev=>prev.filter(x=>x.id!==id))}
+            onAdd={handleAddBudget}
+            onUpdate={handleUpdateBudget}
+            onDelete={handleDeleteBudget}
           />
         )}
 

--- a/src/components/BudgetTracker.tsx
+++ b/src/components/BudgetTracker.tsx
@@ -6,7 +6,7 @@ import { Budget } from '../types';
 
 const safeId = () => (crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2));
 
-export default function BudgetTracker({ budgets, onAdd, onUpdate, onDelete }:{
+function BudgetTracker({ budgets, onAdd, onUpdate, onDelete }:{
   budgets: Budget[];
   onAdd: (b: Budget)=>void;
   onUpdate: (b: Budget)=>void;
@@ -87,3 +87,5 @@ export default function BudgetTracker({ budgets, onAdd, onUpdate, onDelete }:{
     </div>
   );
 }
+
+export default React.memo(BudgetTracker);


### PR DESCRIPTION
## Summary
- memoize budget add, update, and delete handlers with `useCallback`
- wrap `BudgetTracker` component in `React.memo` to avoid unnecessary renders

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*


------
https://chatgpt.com/codex/tasks/task_e_68ae5320d43c8331ba1ec63ca0f8dfef