### PR TITLE
Use deterministic keys for SankeyFlow

### DIFF
--- a/src/components/reports/SankeyFlow.test.tsx
+++ b/src/components/reports/SankeyFlow.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import SankeyFlow from './SankeyFlow';
+
+describe('SankeyFlow', () => {
+  it('preserves DOM nodes when flow order changes', () => {
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
+
+    const flows = [
+      { source: 'A', target: 'B', amount: 5 },
+      { source: 'C', target: 'D', amount: 10 }
+    ];
+
+    act(() => {
+      root.render(<SankeyFlow flows={flows} />);
+    });
+
+    const wrapper = container.querySelector('div')!;
+    const before = Array.from(wrapper.children);
+
+    const reordered = [flows[1], flows[0]];
+    act(() => {
+      root.render(<SankeyFlow flows={reordered} />);
+    });
+
+    const after = Array.from(wrapper.children);
+
+    expect(after[0]).toBe(before[1]);
+    expect(after[1]).toBe(before[0]);
+  });
+});

--- a/src/components/reports/SankeyFlow.tsx
+++ b/src/components/reports/SankeyFlow.tsx
@@ -4,11 +4,13 @@ export default function SankeyFlow({ flows }:{ flows: Array<{source:string; targ
   const total = flows.reduce((s,f)=>s+f.amount,0) || 1;
   return (
     <div className="space-y-2">
-      {flows.map((f,i)=>{
-        const w = Math.max(2, Math.round((f.amount/total)*100));
+      {flows.map((f) => {
+        const w = Math.max(2, Math.round((f.amount / total) * 100));
         return (
-          <div key={i}>
-            <div className="text-xs text-gray-600 dark:text-gray-300">{f.source} → {f.target} (${f.amount.toFixed(2)})</div>
+          <div key={`${f.source}-${f.target}`}>
+            <div className="text-xs text-gray-600 dark:text-gray-300">
+              {f.source} → {f.target} (${f.amount.toFixed(2)})
+            </div>
             <div className="h-2 bg-blue-200 dark:bg-blue-900 rounded overflow-hidden">
               <div className="h-2 bg-blue-600" style={{ width: w + '%' }} />
             </div>


### PR DESCRIPTION
## Summary
- Ensure SankeyFlow items use stable keys derived from source and target
- Add a test asserting that reordered flows retain their DOM nodes

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npx vitest run src/components/reports/SankeyFlow.test.tsx` *(fails: Failed to load PostCSS config)*

------
https://chatgpt.com/codex/tasks/task_e_68ae531f9b708331b1c926853e4e08b6