### PR TITLE
Improve type safety for import/export routines

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import DebtScheduleViewer from './components/DebtScheduleViewer';
 import ManageDebtsModal from './components/modals/ManageDebtsModal';
 import ManageGoalsModal from './components/modals/ManageGoalsModal';
 import ManageObligationsModal from './components/modals/ManageObligationsModal';
-import ImportDataModal from './components/modals/ImportDataModal';
+import ImportDataModal, { ImportPayload } from './components/modals/ImportDataModal';
 import CalculatorModal from './components/modals/CalculatorModal';
 import { payoff } from './logic/debt';
 import { evaluateBadges } from './logic/badges';
@@ -22,7 +22,7 @@ import DebtVelocityChart from './components/reports/DebtVelocityChart';
 import SpendingHeatmap from './components/reports/SpendingHeatmap';
 import GoalWaterfall from './components/reports/GoalWaterfall';
 import SankeyFlow from './components/reports/SankeyFlow';
-import { Budget, Goal, RecurringTransaction, Obligation } from './types';
+import { Budget, Goal, RecurringTransaction, Obligation, Debt } from './types';
 
 type Tab = 'dashboard' | 'budgets' | 'projection' | 'reports';
 
@@ -30,10 +30,10 @@ export default function App(){
   const [tab, setTab] = useState<Tab>('dashboard');
   const [strategy, setStrategy] = useState<'avalanche'|'snowball'>('avalanche');
 
-  const [budgets, setBudgets] = useState<Budget[]>(() => SEEDED.budgets as Budget[]);
-  const [recurring, setRecurring] = useState<RecurringTransaction[]>(() => SEEDED.recurring as RecurringTransaction[]);
-  const [goals, setGoals] = useState<Goal[]>(() => SEEDED.goals as Goal[]);
-  const [debts, setDebts] = useState(() => SEEDED.debts.map(d => ({ ...d })));
+  const [budgets, setBudgets] = useState<Budget[]>(() => SEEDED.budgets);
+  const [recurring, setRecurring] = useState<RecurringTransaction[]>(() => SEEDED.recurring);
+  const [goals, setGoals] = useState<Goal[]>(() => SEEDED.goals);
+  const [debts, setDebts] = useState<Debt[]>(() => SEEDED.debts.map(d => ({ ...d })));
   const [obligations, setObligations] = useState<Obligation[]>([]);
 
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -116,12 +116,12 @@ export default function App(){
       'Budgets: ' + budgets.length + '\n' +
       'Recurring: ' + recurring.length + '\n' +
       'Goals: ' + goals.length + '\n' +
-      'Debts: ' + (debts as any[]).length + '\n' +
-      'BNPL: ' + (SEEDED.bnpl as any[]).length + '\n'
+      'Debts: ' + debts.length + '\n' +
+      'BNPL: ' + SEEDED.bnpl.length + '\n'
     );
   }
 
-  function handleImport(payload: any) {
+  function handleImport(payload: ImportPayload) {
     try {
       if (payload.budgets) setBudgets(payload.budgets);
       if (payload.debts) setDebts(payload.debts);

--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -1,19 +1,90 @@
 import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
+import {
+  Budget,
+  Debt,
+  BNPLPlan,
+  RecurringTransaction,
+  Goal,
+} from '../../types';
 
-type ImportPayload = {
-  budgets?: any[];
-  debts?: any[];
-  bnpl?: any[];
-  recurring?: any[];
-  goals?: any[];
+export type ImportPayload = {
+  budgets?: Budget[];
+  debts?: Debt[];
+  bnpl?: BNPLPlan[];
+  recurring?: RecurringTransaction[];
+  goals?: Goal[];
 };
+
+function isBudget(b: any): b is Budget {
+  return (
+    typeof b === 'object' &&
+    b !== null &&
+    typeof b.id === 'string' &&
+    typeof b.category === 'string' &&
+    typeof b.allocated === 'number' &&
+    typeof b.spent === 'number'
+  );
+}
+
+function isDebt(d: any): d is Debt {
+  return (
+    typeof d === 'object' &&
+    d !== null &&
+    typeof d.id === 'string' &&
+    typeof d.name === 'string' &&
+    typeof d.balance === 'number' &&
+    typeof d.apr === 'number' &&
+    typeof d.minPayment === 'number'
+  );
+}
+
+function isBNPLPlan(p: any): p is BNPLPlan {
+  return (
+    typeof p === 'object' &&
+    p !== null &&
+    typeof p.id === 'string' &&
+    typeof p.provider === 'string' &&
+    typeof p.description === 'string' &&
+    typeof p.total === 'number' &&
+    typeof p.remaining === 'number' &&
+    Array.isArray(p.dueDates)
+  );
+}
+
+function isRecurring(r: any): r is RecurringTransaction {
+  return (
+    typeof r === 'object' &&
+    r !== null &&
+    typeof r.id === 'string' &&
+    typeof r.name === 'string' &&
+    typeof r.type === 'string' &&
+    typeof r.amount === 'number' &&
+    typeof r.cadence === 'string'
+  );
+}
+
+function isGoal(g: any): g is Goal {
+  return (
+    typeof g === 'object' &&
+    g !== null &&
+    typeof g.id === 'string' &&
+    typeof g.name === 'string' &&
+    typeof g.target === 'number' &&
+    typeof g.current === 'number'
+  );
+}
 
 function validate(p: any): p is ImportPayload {
   if (typeof p !== 'object' || p === null) return false;
-  const allowed = ['budgets','debts','bnpl','recurring','goals'];
+  const allowed = ['budgets', 'debts', 'bnpl', 'recurring', 'goals'];
   for (const k of Object.keys(p)) if (!allowed.includes(k)) return false;
+  if (p.budgets && (!Array.isArray(p.budgets) || !p.budgets.every(isBudget))) return false;
+  if (p.debts && (!Array.isArray(p.debts) || !p.debts.every(isDebt))) return false;
+  if (p.bnpl && (!Array.isArray(p.bnpl) || !p.bnpl.every(isBNPLPlan))) return false;
+  if (p.recurring && (!Array.isArray(p.recurring) || !p.recurring.every(isRecurring))) return false;
+  if (p.goals && (!Array.isArray(p.goals) || !p.goals.every(isGoal))) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- tighten ImportDataModal schema with Budget, Debt, BNPLPlan, RecurringTransaction, Goal types
- type guard import payloads and expose ImportPayload
- update App import/export logic to use new ImportPayload and remove loose casts

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5736dc9083319fc3165e0629a412