### PR TITLE
refactor: centralize Debt type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import DebtVelocityChart from './components/reports/DebtVelocityChart';
 import SpendingHeatmap from './components/reports/SpendingHeatmap';
 import GoalWaterfall from './components/reports/GoalWaterfall';
 import SankeyFlow from './components/reports/SankeyFlow';
-import { Budget, Goal, RecurringTransaction, Obligation } from './types';
+import { Budget, Goal, RecurringTransaction, Obligation, Debt } from './types';
 
 type Tab = 'dashboard' | 'budgets' | 'projection' | 'reports';
 
@@ -33,7 +33,7 @@ export default function App(){
   const [budgets, setBudgets] = useState<Budget[]>(() => SEEDED.budgets as Budget[]);
   const [recurring, setRecurring] = useState<RecurringTransaction[]>(() => SEEDED.recurring as RecurringTransaction[]);
   const [goals, setGoals] = useState<Goal[]>(() => SEEDED.goals as Goal[]);
-  const [debts, setDebts] = useState(() => SEEDED.debts.map(d => ({ ...d })));
+  const [debts, setDebts] = useState<Debt[]>(() => SEEDED.debts.map(d => ({ ...d }))); 
   const [obligations, setObligations] = useState<Obligation[]>([]);
 
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -49,7 +49,7 @@ export default function App(){
 
   const plan = useMemo(()=> {
     const unlocked = new Set<string>();
-    return payoff(debts as any, monthlyDebtBudget, strategy, 600, (step)=> {
+    return payoff(debts, monthlyDebtBudget, strategy, 600, (step)=> {
       const newly = evaluateBadges(step, unlocked);
       if (newly.length) toast.success('Milestone: ' + newly.join(', '));
       return newly;
@@ -116,7 +116,7 @@ export default function App(){
       'Budgets: ' + budgets.length + '\n' +
       'Recurring: ' + recurring.length + '\n' +
       'Goals: ' + goals.length + '\n' +
-      'Debts: ' + (debts as any[]).length + '\n' +
+      'Debts: ' + debts.length + '\n' +
       'BNPL: ' + (SEEDED.bnpl as any[]).length + '\n'
     );
   }

--- a/src/components/modals/CalculatorModal.tsx
+++ b/src/components/modals/CalculatorModal.tsx
@@ -3,8 +3,7 @@ import Modal from '../Modal';
 import Input from '../Input';
 import Select from '../Select';
 import { payoff } from '../../logic/debt';
-
-type Debt = { id:string; name:string; balance:number; apr:number; minPayment:number };
+import type { Debt } from '../../types';
 
 export default function CalculatorModal({
   open, onClose, debts

--- a/src/components/modals/DebtModal.tsx
+++ b/src/components/modals/DebtModal.tsx
@@ -2,14 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Modal from '../Modal';
 import Input from '../Input';
 import Button from '../Button';
-
-export type Debt = {
-  id: string;
-  name: string;
-  balance: number;
-  apr: number;
-  minPayment: number;
-};
+import type { Debt } from '../../types';
 
 const safeId = () => (crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2));
 

--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
+import type { Debt } from '../../types';
 
 type ImportPayload = {
   budgets?: any[];
-  debts?: any[];
+  debts?: Debt[];
   bnpl?: any[];
   recurring?: any[];
   goals?: any[];

--- a/src/components/modals/ManageDebtsModal.tsx
+++ b/src/components/modals/ManageDebtsModal.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
-import DebtModal, { Debt } from './DebtModal';
+import DebtModal from './DebtModal';
+import type { Debt } from '../../types';
 
 export default function ManageDebtsModal({
   open, onClose, debts, onChange

--- a/src/logic/debt.ts
+++ b/src/logic/debt.ts
@@ -1,10 +1,5 @@
-export type Debt = {
-  id: string;
-  name: string;
-  balance: number;
-  apr: number; // annual percent
-  minPayment: number;
-};
+import type { Debt } from '../types';
+export type { Debt };
 
 export type PlanStep = {
   month: number;


### PR DESCRIPTION
## Summary
- centralize Debt type definition and re-export from logic layer
- apply shared Debt type across App and modals, removing any casts
- type import payload to reference shared Debt type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae57356fe88331959c34ed97a7c606