### PR TITLE
Add structured import payload and validation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import DebtScheduleViewer from './components/DebtScheduleViewer';
 import ManageDebtsModal from './components/modals/ManageDebtsModal';
 import ManageGoalsModal from './components/modals/ManageGoalsModal';
 import ManageObligationsModal from './components/modals/ManageObligationsModal';
-import ImportDataModal from './components/modals/ImportDataModal';
+import ImportDataModal, { ImportPayload } from './components/modals/ImportDataModal';
 import CalculatorModal from './components/modals/CalculatorModal';
 import { payoff } from './logic/debt';
 import { evaluateBadges } from './logic/badges';
@@ -30,10 +30,10 @@ export default function App(){
   const [tab, setTab] = useState<Tab>('dashboard');
   const [strategy, setStrategy] = useState<'avalanche'|'snowball'>('avalanche');
 
-  const [budgets, setBudgets] = useState<Budget[]>(() => SEEDED.budgets as Budget[]);
-  const [recurring, setRecurring] = useState<RecurringTransaction[]>(() => SEEDED.recurring as RecurringTransaction[]);
-  const [goals, setGoals] = useState<Goal[]>(() => SEEDED.goals as Goal[]);
-  const [debts, setDebts] = useState<Debt[]>(() => SEEDED.debts.map(d => ({ ...d }))); 
+  const [budgets, setBudgets] = useState<Budget[]>(() => SEEDED.budgets);
+  const [recurring, setRecurring] = useState<RecurringTransaction[]>(() => SEEDED.recurring);
+  const [goals, setGoals] = useState<Goal[]>(() => SEEDED.goals);
+  const [debts, setDebts] = useState<Debt[]>(() => SEEDED.debts.map(d => ({ ...d })));
   const [obligations, setObligations] = useState<Obligation[]>([]);
 
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -121,12 +121,12 @@ export default function App(){
     );
   }
 
-  function handleImport(payload: any) {
+  function handleImport(payload: ImportPayload) {
     try {
-      if (payload.budgets) setBudgets(payload.budgets);
-      if (payload.debts) setDebts(payload.debts);
-      if (payload.recurring) setRecurring(payload.recurring);
-      if (payload.goals) setGoals(payload.goals);
+      setBudgets(payload.budgets);
+      setDebts(payload.debts);
+      setRecurring(payload.recurring);
+      setGoals(payload.goals);
       toast.success('Import complete');
     } catch (e) {
       toast.error('Import failed: ' + (e as any)?.message);

--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -1,21 +1,17 @@
 import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
-import type { Debt } from '../../types';
+import type { ImportPayload } from '../../types';
+export type { ImportPayload } from '../../types';
 
-type ImportPayload = {
-  budgets?: any[];
-  debts?: Debt[];
-  bnpl?: any[];
-  recurring?: any[];
-  goals?: any[];
-};
-
-function validate(p: any): p is ImportPayload {
-  if (typeof p !== 'object' || p === null) return false;
-  const allowed = ['budgets','debts','bnpl','recurring','goals'];
-  for (const k of Object.keys(p)) if (!allowed.includes(k)) return false;
-  return true;
+function validate(payload: any): payload is ImportPayload {
+  return (
+    Array.isArray(payload?.budgets) &&
+    Array.isArray(payload?.debts) &&
+    Array.isArray(payload?.bnplPlans) &&
+    Array.isArray(payload?.recurring) &&
+    Array.isArray(payload?.goals)
+  );
 }
 
 export default function ImportDataModal({
@@ -39,11 +35,14 @@ export default function ImportDataModal({
     setError(null);
     try {
       const json = JSON.parse(text);
-      if (!validate(json)) { setError('Invalid schema. Expect a JSON object with keys: budgets, debts, bnpl, recurring, goals'); return; }
+      if (!validate(json)) {
+        setError('Invalid schema. Expect a JSON object with keys: budgets, debts, bnplPlans, recurring, goals');
+        return;
+      }
       onImport(json);
       onClose();
-    } catch (e: any) {
-      setError('Invalid JSON: ' + (e?.message || String(e)));
+    } catch (e) {
+      setError('Invalid JSON: ' + (e instanceof Error ? e.message : String(e)));
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,11 @@ export interface CashFlowProjectionPoint {
   label: string;
   endingBalance: number;
 }
+
+export interface ImportPayload {
+  budgets: Budget[];
+  debts: Debt[];
+  bnplPlans: BNPLPlan[];
+  recurring: RecurringTransaction[];
+  goals: Goal[];
+}


### PR DESCRIPTION
## Summary
- Define `ImportPayload` interface for importing budgets, debts, bnpl plans, recurring transactions and goals
- Add type-guard validation in `ImportDataModal` and export `ImportPayload`
- Wire `ImportPayload` into `App` and remove `any` casts

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5c52086883318cf8ecfded15e94c