### PR TITLE
fix: export ImportPayload type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import SpendingHeatmap from './components/reports/SpendingHeatmap';
 import GoalWaterfall from './components/reports/GoalWaterfall';
 import SankeyFlow from './components/reports/SankeyFlow';
 import { Budget, Goal, RecurringTransaction, Obligation, Debt } from './types';
+import type { ImportPayload } from './types';
 
 type Tab = 'dashboard' | 'budgets' | 'projection' | 'reports';
 
@@ -121,7 +122,7 @@ export default function App(){
     );
   }
 
-  function handleImport(payload: any) {
+  function handleImport(payload: ImportPayload) {
     try {
       if (payload.budgets) setBudgets(payload.budgets);
       if (payload.debts) setDebts(payload.debts);

--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -1,15 +1,8 @@
 import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
-import type { Debt } from '../../types';
-
-type ImportPayload = {
-  budgets?: any[];
-  debts?: Debt[];
-  bnpl?: any[];
-  recurring?: any[];
-  goals?: any[];
-};
+import type { Debt, ImportPayload } from '../../types';
+export type { ImportPayload } from '../../types';
 
 function validate(p: any): p is ImportPayload {
   if (typeof p !== 'object' || p === null) return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,11 @@ export interface CashFlowProjectionPoint {
   label: string;
   endingBalance: number;
 }
+
+export interface ImportPayload {
+  budgets?: any[];
+  debts?: Debt[];
+  bnpl?: any[];
+  recurring?: any[];
+  goals?: any[];
+}


### PR DESCRIPTION
## Summary
- expose `ImportPayload` from types and re-export via ImportDataModal
- use `import type` for `ImportPayload` and type handleImport

## Testing
- `npm run build` *(fails: Failed to resolve entry for package "json2csv")*
- `npx tsc --noEmit` *(fails: Object is possibly 'undefined'; Could not find declaration file for module 'json2csv')*


------
https://chatgpt.com/codex/tasks/task_e_68ae5d54d78c8331b98343eb1dfae150