### PR TITLE
Allow optional arrays in import payload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import DebtVelocityChart from './components/reports/DebtVelocityChart';
 import SpendingHeatmap from './components/reports/SpendingHeatmap';
 import GoalWaterfall from './components/reports/GoalWaterfall';
 import SankeyFlow from './components/reports/SankeyFlow';
-import { Budget, Goal, RecurringTransaction, Obligation, Debt } from './types';
+import { Budget, Goal, RecurringTransaction, Obligation, Debt, ImportPayload } from './types';
 
 type Tab = 'dashboard' | 'budgets' | 'projection' | 'reports';
 
@@ -121,12 +121,12 @@ export default function App(){
     );
   }
 
-  function handleImport(payload: any) {
+  function handleImport(payload: ImportPayload) {
     try {
-      if (payload.budgets) setBudgets(payload.budgets);
-      if (payload.debts) setDebts(payload.debts);
-      if (payload.recurring) setRecurring(payload.recurring);
-      if (payload.goals) setGoals(payload.goals);
+      if (payload.budgets !== undefined) setBudgets(payload.budgets);
+      if (payload.debts !== undefined) setDebts(payload.debts);
+      if (payload.recurring !== undefined) setRecurring(payload.recurring);
+      if (payload.goals !== undefined) setGoals(payload.goals);
       toast.success('Import complete');
     } catch (e) {
       toast.error('Import failed: ' + (e as any)?.message);

--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -1,20 +1,15 @@
 import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
-import type { Debt } from '../../types';
-
-type ImportPayload = {
-  budgets?: any[];
-  debts?: Debt[];
-  bnpl?: any[];
-  recurring?: any[];
-  goals?: any[];
-};
+import type { ImportPayload } from '../../types';
 
 function validate(p: any): p is ImportPayload {
   if (typeof p !== 'object' || p === null) return false;
-  const allowed = ['budgets','debts','bnpl','recurring','goals'];
-  for (const k of Object.keys(p)) if (!allowed.includes(k)) return false;
+  const allowed = ['budgets', 'debts', 'bnpl', 'recurring', 'goals'];
+  for (const k of Object.keys(p)) {
+    if (!allowed.includes(k)) return false;
+    if (!Array.isArray((p as any)[k])) return false;
+  }
   return true;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,3 +64,11 @@ export interface CashFlowProjectionPoint {
   label: string;
   endingBalance: number;
 }
+
+export interface ImportPayload {
+  budgets?: Budget[];
+  debts?: Debt[];
+  bnpl?: BNPLPlan[];
+  recurring?: RecurringTransaction[];
+  goals?: Goal[];
+}


### PR DESCRIPTION
## Summary
- export a shared `ImportPayload` with optional fields for budgets, debts, bnpl, recurring and goals
- validate import data by ensuring provided keys are arrays while allowing omissions
- only update application state for the data arrays present in the import payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae5d5727188331ae43aa6cc35ff7a7