### PR TITLE
Fix ImportDataModal validation and schema type

### DIFF
--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -8,7 +8,7 @@ function validate(payload: any): payload is ImportPayload {
   return (
     Array.isArray(payload?.budgets) &&
     Array.isArray(payload?.debts) &&
-    Array.isArray(payload?.bnplPlans) &&
+    Array.isArray(payload?.bnpl) &&
     Array.isArray(payload?.recurring) &&
     Array.isArray(payload?.goals)
   );
@@ -36,7 +36,7 @@ export default function ImportDataModal({
     try {
       const json = JSON.parse(text);
       if (!validate(json)) {
-        setError('Invalid schema. Expect a JSON object with keys: budgets, debts, bnplPlans, recurring, goals');
+        setError('Invalid schema. Expect a JSON object with keys: budgets, debts, bnpl, recurring, goals');
         return;
       }
       onImport(json);

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,7 @@ export interface CashFlowProjectionPoint {
 export interface ImportPayload {
   budgets: Budget[];
   debts: Debt[];
-  bnplPlans: BNPLPlan[];
+  bnpl: BNPLPlan[];
   recurring: RecurringTransaction[];
   goals: Goal[];
 }


### PR DESCRIPTION
## Summary
- align import/export of `ImportPayload`
- validate `bnpl` array and update error messaging
- rename `bnplPlans` to `bnpl` in `ImportPayload` type

## Testing
- `npm run build` *(fails: Failed to resolve entry for package "json2csv" during Vite build)*
- `npx tsc --noEmit` *(fails: multiple TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ae616b6440833190a2961d13f84df3