### PR TITLE
feat: validate imported data

### DIFF
--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -1,16 +1,89 @@
 import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
-import type { ImportPayload } from '../../types';
+import type {
+  ImportPayload,
+  Budget,
+  Debt,
+  BNPLPlan,
+  RecurringTransaction,
+  Goal,
+  Cadence,
+  TxnType
+} from '../../types';
 export type { ImportPayload } from '../../types';
+
+const CADENCES: Cadence[] = ['weekly', 'biweekly', 'monthly', 'quarterly', 'yearly'];
+const TXN_TYPES: TxnType[] = ['income', 'expense'];
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}
+
+function isNumber(v: unknown): v is number {
+  return typeof v === 'number' && !Number.isNaN(v);
+}
+
+function isBudget(item: any): item is Budget {
+  return (
+    isString(item?.id) &&
+    isString(item?.category) &&
+    isNumber(item?.allocated) &&
+    isNumber(item?.spent)
+  );
+}
+
+function isDebt(item: any): item is Debt {
+  return (
+    isString(item?.id) &&
+    isString(item?.name) &&
+    isNumber(item?.balance) &&
+    isNumber(item?.apr) &&
+    isNumber(item?.minPayment)
+  );
+}
+
+function isBNPLPlan(item: any): item is BNPLPlan {
+  return (
+    isString(item?.id) &&
+    ['PayPal', 'Affirm', 'Klarna'].includes(item?.provider) &&
+    isString(item?.description) &&
+    isNumber(item?.total) &&
+    isNumber(item?.remaining) &&
+    Array.isArray(item?.dueDates) &&
+    item.dueDates.every(isString) &&
+    (item.apr === undefined || isNumber(item.apr))
+  );
+}
+
+function isRecurringTransaction(item: any): item is RecurringTransaction {
+  return (
+    isString(item?.id) &&
+    isString(item?.name) &&
+    TXN_TYPES.includes(item?.type) &&
+    isNumber(item?.amount) &&
+    CADENCES.includes(item?.cadence)
+  );
+}
+
+function isGoal(item: any): item is Goal {
+  return (
+    isString(item?.id) &&
+    isString(item?.name) &&
+    isNumber(item?.target) &&
+    isNumber(item?.current) &&
+    (item.due === undefined || isString(item.due)) &&
+    (item.priority === undefined || isNumber(item.priority))
+  );
+}
 
 function validate(payload: any): payload is ImportPayload {
   return (
-    Array.isArray(payload?.budgets) &&
-    Array.isArray(payload?.debts) &&
-    Array.isArray(payload?.bnpl) &&
-    Array.isArray(payload?.recurring) &&
-    Array.isArray(payload?.goals)
+    Array.isArray(payload?.budgets) && payload.budgets.every(isBudget) &&
+    Array.isArray(payload?.debts) && payload.debts.every(isDebt) &&
+    Array.isArray(payload?.bnpl) && payload.bnpl.every(isBNPLPlan) &&
+    Array.isArray(payload?.recurring) && payload.recurring.every(isRecurringTransaction) &&
+    Array.isArray(payload?.goals) && payload.goals.every(isGoal)
   );
 }
 


### PR DESCRIPTION
## Summary
- add runtime type guards for imported budget, debt, BNPLPlan, recurring transaction, and goal data
- validate arrays against these guards during data import

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae64f81e1083318fb38fe2c15ae9b4