### PR TITLE
Handle malformed localStorage entries in useLocalList

### DIFF
--- a/src/hooks/useLocalList.ts
+++ b/src/hooks/useLocalList.ts
@@ -3,7 +3,14 @@ import { useEffect, useState } from 'react';
 export default function useLocalList<T>(key: string, initial: T[]) {
   const [list, setList] = useState<T[]>(() => {
     const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T[]) : initial;
+    if (!raw) return initial;
+    try {
+      return JSON.parse(raw) as T[];
+    } catch (err) {
+      console.warn(`Failed to parse localStorage item "${key}":`, err);
+      localStorage.removeItem(key);
+      return initial;
+    }
   });
   useEffect(() => {
     localStorage.setItem(key, JSON.stringify(list));


### PR DESCRIPTION
## Summary
- handle JSON parse failures in useLocalList hook
- log warnings and clear bad localStorage entries to prevent repeated errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae692f99008331a3e3694f6544f182