### PR TITLE
Add alt modifier support to useHotkeys hook

### DIFF
--- a/src/hooks/useHotkeys.ts
+++ b/src/hooks/useHotkeys.ts
@@ -5,9 +5,24 @@ interface ParsedBinding {
   ctrl: boolean;
   meta: boolean;
   shift: boolean;
+  alt: boolean;
   fn: (e: KeyboardEvent) => void;
 }
 
+/**
+ * Registers keyboard shortcut bindings.
+ *
+ * Each binding is a tuple of a combo string and handler function. Supported
+ * modifiers are `ctrl`, `meta`, `shift`, and `alt` (or `option`).
+ *
+ * Example:
+ * ```ts
+ * useHotkeys([
+ *   ['ctrl+alt+k', (e) => console.log('hotkey', e)],
+ *   ['option+p', save],
+ * ]);
+ * ```
+ */
 export default function useHotkeys(bindings: Array<[string, (e: KeyboardEvent) => void]>) {
   // Consumers should memoize `bindings` to avoid unnecessary updates
   // (e.g. with `useMemo`).
@@ -22,6 +37,7 @@ export default function useHotkeys(bindings: Array<[string, (e: KeyboardEvent) =
           ctrl: parts.includes('ctrl'),
           meta: parts.includes('meta'),
           shift: parts.includes('shift'),
+          alt: parts.includes('alt') || parts.includes('option'),
           fn,
         };
       }),
@@ -30,10 +46,11 @@ export default function useHotkeys(bindings: Array<[string, (e: KeyboardEvent) =
 
   useEffect(() => {
     function handler(e: KeyboardEvent) {
-      for (const { key, ctrl, meta, shift, fn } of bindingsRef.current) {
+      for (const { key, ctrl, meta, shift, alt, fn } of bindingsRef.current) {
         if (meta && !e.metaKey) continue;
         if (ctrl && !e.ctrlKey) continue;
         if (shift && !e.shiftKey) continue;
+        if (alt && !e.altKey) continue;
         if (e.key.toLowerCase() === key) {
           e.preventDefault();
           fn(e);


### PR DESCRIPTION
## Summary
- support `alt`/`option` modifier in `useHotkeys`
- document new modifier and example usage

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6930a65c833180f9fcc0a76282e6