### PR TITLE
refactor: tighten import payload validation

### DIFF
--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -78,12 +78,19 @@ function isGoal(item: any): item is Goal {
 }
 
 function validate(payload: any): payload is ImportPayload {
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    return false;
+  }
+  const allowed = ['budgets', 'debts', 'bnpl', 'recurring', 'goals'];
+  if (!Object.keys(payload).every((k) => allowed.includes(k))) {
+    return false;
+  }
   return (
-    Array.isArray(payload?.budgets) && payload.budgets.every(isBudget) &&
-    Array.isArray(payload?.debts) && payload.debts.every(isDebt) &&
-    Array.isArray(payload?.bnpl) && payload.bnpl.every(isBNPLPlan) &&
-    Array.isArray(payload?.recurring) && payload.recurring.every(isRecurringTransaction) &&
-    Array.isArray(payload?.goals) && payload.goals.every(isGoal)
+    (!('budgets' in payload) || (Array.isArray(payload.budgets) && payload.budgets.every(isBudget))) &&
+    (!('debts' in payload) || (Array.isArray(payload.debts) && payload.debts.every(isDebt))) &&
+    (!('bnpl' in payload) || (Array.isArray(payload.bnpl) && payload.bnpl.every(isBNPLPlan))) &&
+    (!('recurring' in payload) || (Array.isArray(payload.recurring) && payload.recurring.every(isRecurringTransaction))) &&
+    (!('goals' in payload) || (Array.isArray(payload.goals) && payload.goals.every(isGoal)))
   );
 }
 
@@ -109,7 +116,9 @@ export default function ImportDataModal({
     try {
       const json = JSON.parse(text);
       if (!validate(json)) {
-        setError('Invalid schema. Expect a JSON object with keys: budgets, debts, bnpl, recurring, goals');
+        setError(
+          'Invalid schema. Expect an object with optional arrays budgets, debts, bnpl, recurring, goals and no other keys'
+        );
         return;
       }
       onImport(json);


### PR DESCRIPTION
## Summary
- reintroduce and apply type guards for imported budgets, debts, BNPL plans, recurring transactions, and goals
- relax import validation to allow optional arrays while rejecting extra keys
- clarify error message for invalid import data

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6b001c6c833197d694f9a214a1f1