### PR TITLE
feat: guard window access in useHotkeys

### DIFF
--- a/src/hooks/useHotkeys.ts
+++ b/src/hooks/useHotkeys.ts
@@ -59,7 +59,12 @@ export default function useHotkeys(bindings: Array<[string, (e: KeyboardEvent) =
       }
     }
 
+    if (typeof window === 'undefined') return;
     window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('keydown', handler);
+      }
+    };
   }, []);
 }


### PR DESCRIPTION
## Summary
- add window existence checks before adding and removing hotkey listeners

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6cabffbc8331ba71e76bcdac2712