### PR TITLE
Lowercase keywords in command filter

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -11,7 +11,9 @@ export default function CommandPalette({ open, onClose, commands }:{
   const list = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return commands;
-    return commands.filter(c => c.label.toLowerCase().includes(q) || (c.keywords||'').includes(q));
+    return commands.filter(
+      c => c.label.toLowerCase().includes(q) || (c.keywords || '').toLowerCase().includes(q)
+    );
   }, [commands, query]);
   if (!open) return null;
   return (


### PR DESCRIPTION
## Summary
- Ensure command palette keywords are lowercased before matching the query

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f30d8708331b224db5515c04917