### PR TITLE
Handle missing localStorage in useLocalList hook

### DIFF
--- a/src/hooks/useLocalList.ts
+++ b/src/hooks/useLocalList.ts
@@ -1,8 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 
 export default function useLocalList<T>(key: string, initial: T[]) {
+  const hasStorage = typeof window !== 'undefined' && 'localStorage' in window;
+  if (!hasStorage) {
+    const noop: Dispatch<SetStateAction<T[]>> = () => {};
+    return [initial, noop] as const;
+  }
+
   const [list, setList] = useState<T[]>(() => {
-    const raw = localStorage.getItem(key);
+    const raw = window.localStorage.getItem(key);
     if (!raw) return initial;
     try {
       return JSON.parse(raw) as T[];
@@ -11,12 +17,12 @@ export default function useLocalList<T>(key: string, initial: T[]) {
         `Failed to parse localStorage item "${key}". Removing corrupted data:`,
         error,
       );
-      localStorage.removeItem(key);
+      window.localStorage.removeItem(key);
       return initial;
     }
   });
   useEffect(() => {
-    localStorage.setItem(key, JSON.stringify(list));
+    window.localStorage.setItem(key, JSON.stringify(list));
   }, [key, list]);
   return [list, setList] as const;
 }


### PR DESCRIPTION
## Summary
- guard `useLocalList` against missing browser storage
- use `window.localStorage` only when available

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f2f21c883318f82aa52a46beea2