### PR TITLE
Guard window access in Modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -16,9 +16,15 @@ export default function Modal({
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKey);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', onKey);
+    }
     setTimeout(() => ref.current?.querySelector<HTMLElement>('button, [href], input, select, textarea')?.focus(), 0);
-    return () => window.removeEventListener('keydown', onKey);
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('keydown', onKey);
+      }
+    };
   }, [open, onClose]);
 
   if (!open) return null;


### PR DESCRIPTION
## Summary
- ensure Modal's keydown listener only registers when `window` exists to support non-browser environments

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f2d14d483318d6e7b8e5a85053e