### PR TITLE
docs: specify Node.js version in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Financial management app built with React, TypeScript, Vite and Tailwind CSS.
 
 ### Installation
 
+Requires **Node.js 18+** and **npm 9+** (npm is included with Node.js). No other global tools are required.
+
 ```bash
 npm install
 ```


### PR DESCRIPTION
## Summary
- document Node.js 18+ and npm 9+ requirement in Installation section

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7588ea9c8331bfa1c0fd1a380c3d