### PR TITLE
Ensure Input and Select labels reference generated ids

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,12 +1,24 @@
 import React from 'react';
 
 export default function Input({
-  label, className = '', ...props
+  label,
+  id,
+  className = '',
+  ...props
 }: { label?: string } & React.InputHTMLAttributes<HTMLInputElement>) {
+  const inputId = id ?? React.useId();
   return (
     <div className="flex flex-col">
-      {label && <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</label>}
+      {label && (
+        <label
+          htmlFor={inputId}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          {label}
+        </label>
+      )}
       <input
+        id={inputId}
         className={`px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent ${className}`}
         {...props}
       />

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
 
 export default function Select({
-  label, className = '', children, ...props
+  label,
+  id,
+  className = '',
+  children,
+  ...props
 }: { label?: string } & React.SelectHTMLAttributes<HTMLSelectElement>) {
+  const selectId = id ?? React.useId();
   return (
     <div className="flex flex-col">
-      {label && <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</label>}
+      {label && (
+        <label
+          htmlFor={selectId}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+        >
+          {label}
+        </label>
+      )}
       <select
+        id={selectId}
         className={`px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent ${className}`}
         {...props}
       >


### PR DESCRIPTION
## Summary
- Generate stable ids for Input and Select when no id is provided
- Link labels to controls via `htmlFor` and `id` for better accessibility

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7d0bc2088331a9bb8cc5a07e430d