### PR TITLE
Ensure useLocalList hooks are always invoked

### DIFF
--- a/src/hooks/useLocalList.ts
+++ b/src/hooks/useLocalList.ts
@@ -1,13 +1,11 @@
-import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function useLocalList<T>(key: string, initial: T[]) {
   const hasStorage = typeof window !== 'undefined' && 'localStorage' in window;
-  if (!hasStorage) {
-    const noop: Dispatch<SetStateAction<T[]>> = () => {};
-    return [initial, noop] as const;
-  }
 
   const [list, setList] = useState<T[]>(() => {
+    if (!hasStorage) return initial;
+
     const raw = window.localStorage.getItem(key);
     if (!raw) return initial;
     try {
@@ -21,8 +19,12 @@ export default function useLocalList<T>(key: string, initial: T[]) {
       return initial;
     }
   });
+
   useEffect(() => {
+    if (!hasStorage) return;
+
     window.localStorage.setItem(key, JSON.stringify(list));
-  }, [key, list]);
+  }, [hasStorage, key, list]);
+
   return [list, setList] as const;
 }


### PR DESCRIPTION
## Summary
- Always initialize `useState` and `useEffect` in `useLocalList`
- Guard localStorage usage to fall back gracefully when unavailable

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7d0b23c8833181fb4bd1d5a7b734