### PR TITLE
Enable keyboard navigation in command palette

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -7,8 +7,11 @@ export default function CommandPalette({ open, onClose, commands }:{
   open:boolean; onClose:()=>void; commands:Command[];
 }) {
   const [query, setQuery] = useState('');
+  const [index, setIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   useEffect(() => { if (open) setTimeout(()=>inputRef.current?.focus(), 0); else setQuery(''); }, [open]);
+  useEffect(() => { if (open) setIndex(0); }, [open, query]);
+
   const list = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return commands;
@@ -16,9 +19,27 @@ export default function CommandPalette({ open, onClose, commands }:{
       c => c.label.toLowerCase().includes(q) || (c.keywords || '').toLowerCase().includes(q)
     );
   }, [commands, query]);
-
-  const escBinding = useMemo(() => (open ? [['escape', () => onClose()]] : []), [open, onClose]);
-  useHotkeys(escBinding);
+  const hotkeys = useMemo(() => (
+    open ? [
+      ['escape', () => onClose()],
+      ['arrowdown', () => {
+        if (!list.length) return;
+        setIndex(i => (i + 1) % list.length);
+      }],
+      ['arrowup', () => {
+        if (!list.length) return;
+        setIndex(i => (i - 1 + list.length) % list.length);
+      }],
+      ['enter', () => {
+        const cmd = list[index];
+        if (cmd) {
+          cmd.action();
+          onClose();
+        }
+      }]
+    ] : []
+  ), [open, onClose, list, index]);
+  useHotkeys(hotkeys);
 
   if (!open) return null;
   return (
@@ -31,13 +52,24 @@ export default function CommandPalette({ open, onClose, commands }:{
           <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">Esc to close</div>
         </div>
         <div className="bg-white dark:bg-gray-900 max-h-80 overflow-auto">
-          {list.map(c => (
-            <button key={c.id} onClick={() => { c.action(); onClose(); }}
-              className="w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 border-b border-gray-100 dark:border-gray-800">
+          {list.map((c, i) => (
+            <button
+              key={c.id}
+              aria-selected={i === index}
+              onClick={() => {
+                c.action();
+                onClose();
+              }}
+              className={`w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 border-b border-gray-100 dark:border-gray-800 ${
+                i === index ? 'bg-gray-100 dark:bg-gray-800' : ''
+              }`}
+            >
               {c.label}
             </button>
           ))}
-          {!list.length && <div className="px-4 py-6 text-sm text-gray-500 dark:text-gray-400">No results</div>}
+          {!list.length && (
+            <div className="px-4 py-6 text-sm text-gray-500 dark:text-gray-400">No results</div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- keep a focused index in command palette state
- use ArrowUp/ArrowDown to change selection and Enter to run the command
- visually highlight the focused command for feedback

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7d0d118483319b7fdf2e9b434335