### PR TITLE
Add 2025 tax bracket boundary tests

### DIFF
--- a/src/taxes/__snapshots__/california2025.test.ts.snap
+++ b/src/taxes/__snapshots__/california2025.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`estimateCaliforniaTax > calculates tax at bracket boundaries 1`] = `
+[
+  104.12,
+  389.56,
+  960.56,
+  1867.94,
+  3009.38,
+  29122.57,
+  36314.44,
+  67876.47,
+]
+`;

--- a/src/taxes/__snapshots__/federal2025.test.ts.snap
+++ b/src/taxes/__snapshots__/federal2025.test.ts.snap
@@ -1,0 +1,38 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`estimateFederalTax > calculates tax at bracket boundaries for all filing statuses 1`] = `
+{
+  "head": [
+    1655,
+    7241,
+    15469,
+    37417,
+    53977,
+    181954.5,
+  ],
+  "married_joint": [
+    2320,
+    10852,
+    34337,
+    78221,
+    111357,
+    196669.5,
+  ],
+  "married_separate": [
+    1160,
+    5426,
+    17168.5,
+    39110.5,
+    55678.5,
+    98334.75,
+  ],
+  "single": [
+    1160,
+    5426,
+    17168.5,
+    39110.5,
+    55678.5,
+    183647.25,
+  ],
+}
+`;

--- a/src/taxes/__snapshots__/oregon2025.test.ts.snap
+++ b/src/taxes/__snapshots__/oregon2025.test.ts.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`estimateOregonTax > calculates tax at bracket boundaries 1`] = `
+[
+  209,
+  654.5,
+  10629.5,
+]
+`;

--- a/src/taxes/california2025.test.ts
+++ b/src/taxes/california2025.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { estimateCaliforniaTax } from './california2025';
+
+describe('estimateCaliforniaTax', () => {
+  const boundaries = [10412, 24684, 38959, 54082, 68350, 349137, 418961, 698271];
+
+  it('calculates tax at bracket boundaries', () => {
+    const taxes = boundaries.map((income) => estimateCaliforniaTax(income));
+    expect(taxes).toMatchSnapshot();
+  });
+
+  it('returns 0 for no income', () => {
+    expect(estimateCaliforniaTax(0)).toBe(0);
+  });
+
+  it('calculates tax in the top bracket', () => {
+    expect(estimateCaliforniaTax(1_000_000)).toBe(104989.14);
+  });
+});

--- a/src/taxes/federal2025.test.ts
+++ b/src/taxes/federal2025.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { estimateFederalTax, type FilingStatus } from './federal2025';
+
+describe('estimateFederalTax', () => {
+  const boundaries: Record<FilingStatus, number[]> = {
+    single: [11600, 47150, 100525, 191950, 243725, 609350],
+    married_joint: [23200, 94300, 201050, 383900, 487450, 731200],
+    married_separate: [11600, 47150, 100525, 191950, 243725, 365600],
+    head: [16550, 63100, 100500, 191950, 243700, 609350]
+  };
+
+  it('calculates tax at bracket boundaries for all filing statuses', () => {
+    const results: Record<FilingStatus, number[]> = {
+      single: [],
+      married_joint: [],
+      married_separate: [],
+      head: []
+    };
+    for (const status of Object.keys(boundaries) as FilingStatus[]) {
+      results[status] = boundaries[status].map((income) => estimateFederalTax(income, status));
+    }
+    expect(results).toMatchSnapshot();
+  });
+
+  it('returns 0 for no income', () => {
+    expect(estimateFederalTax(0)).toBe(0);
+  });
+
+  it('calculates tax in the top bracket', () => {
+    expect(estimateFederalTax(1_000_000)).toBe(328187.75);
+  });
+});

--- a/src/taxes/oregon2025.test.ts
+++ b/src/taxes/oregon2025.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { estimateOregonTax } from './oregon2025';
+
+describe('estimateOregonTax', () => {
+  const boundaries = [4400, 11000, 125000];
+
+  it('calculates tax at bracket boundaries', () => {
+    const taxes = boundaries.map((income) => estimateOregonTax(income));
+    expect(taxes).toMatchSnapshot();
+  });
+
+  it('returns 0 for no income', () => {
+    expect(estimateOregonTax(0)).toBe(0);
+  });
+
+  it('calculates tax in the top bracket', () => {
+    expect(estimateOregonTax(1_000_000)).toBe(97254.5);
+  });
+});


### PR DESCRIPTION
## Summary
- add California tax tests for 2025 including bracket boundaries and edge cases
- cover 2025 federal tax brackets for all filing statuses
- verify Oregon tax calculations at 2025 bracket thresholds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d0eb774833194a4c8d9f12e1ff9