### PR TITLE
Add Zod schema for import validation

### DIFF
--- a/src/schema/import.ts
+++ b/src/schema/import.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+const budgetSchema = z.object({
+  id: z.string(),
+  category: z.string(),
+  allocated: z.number(),
+  spent: z.number()
+});
+
+const debtSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  balance: z.number(),
+  apr: z.number(),
+  minPayment: z.number()
+});
+
+const bnplPlanSchema = z.object({
+  id: z.string(),
+  provider: z.enum(['PayPal', 'Affirm', 'Klarna']),
+  description: z.string(),
+  total: z.number(),
+  remaining: z.number(),
+  dueDates: z.array(z.string()),
+  apr: z.number().optional()
+});
+
+const recurringTransactionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(['income', 'expense']),
+  amount: z.number(),
+  cadence: z.enum(['weekly', 'biweekly', 'monthly', 'quarterly', 'yearly'])
+});
+
+const goalSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  target: z.number(),
+  current: z.number(),
+  due: z.string().optional(),
+  priority: z.number().optional()
+});
+
+export const importSchema = z.object({
+  budgets: z.array(budgetSchema),
+  debts: z.array(debtSchema),
+  bnpl: z.array(bnplPlanSchema),
+  recurring: z.array(recurringTransactionSchema),
+  goals: z.array(goalSchema)
+});
+
+export type ImportPayload = z.infer<typeof importSchema>;


### PR DESCRIPTION
## Summary
- define `importSchema` with Zod for import payload structure
- validate import data via `safeParse` and surface detailed errors in `ImportDataModal`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7d0c4af48331aed32254565e2e5d