### PR TITLE
Add due date reminders and calendar export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,12 @@
+self.addEventListener('message', (event) => {
+  const data = event.data;
+  if (!data || data.type !== 'schedule') return;
+  const items = data.items || [];
+  items.forEach((item) => {
+    const time = new Date(item.due + 'T09:00:00').getTime() - Date.now();
+    const delay = Math.max(0, time);
+    setTimeout(() => {
+      self.registration.showNotification(item.title, { body: `Due ${item.due}` });
+    }, delay);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useMemo, useState, useEffect } from 'react';
 import Button from './components/Button';
 import ThemeToggle from './components/ThemeToggle';
 import CommandPalette from './components/CommandPalette';
@@ -17,6 +17,7 @@ import { payoff } from './logic/debt';
 import { evaluateBadges } from './logic/badges';
 import { SEEDED } from './utils/constants';
 import { exportJSON, exportCSV, exportPDF, exportCSVBudgets } from './utils/export';
+import { startDailyChecks } from './utils/notifications';
 import toast from 'react-hot-toast';
 import { Budget, Goal, RecurringTransaction, Obligation, Debt, BNPLPlan } from './types';
 
@@ -46,6 +47,7 @@ export default function App(){
   const [showManageObligations, setShowManageObligations] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [showCalc, setShowCalc] = useState(false);
+  useEffect(() => { startDailyChecks(bnpl, obligations); }, [bnpl, obligations]);
 
   const monthlyDebtBudget = useMemo(()=> budgets.find(b=>b.category==='Debt')?.allocated ?? 1500, [budgets]);
 

--- a/src/components/BNPLTrackerModal.tsx
+++ b/src/components/BNPLTrackerModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Modal from './Modal';
 import { BNPLPlan } from '../types';
+import { isReminderEnabled, setReminderEnabled } from '../utils/notifications';
 
 function daysUntil(dIso: string) {
   const d = new Date(dIso + 'T00:00:00Z'); // UTC midnight
@@ -29,7 +30,16 @@ export default function BNPLTrackerModal({ open, onClose, plans }:{
                 <div className="font-semibold">{p.provider}</div>
                 <div className="text-sm text-gray-600 dark:text-gray-300">{p.description}</div>
               </div>
-              <div className="text-sm">Remaining: <b>${p.remaining.toFixed(2)}</b> / ${p.total.toFixed(2)}</div>
+              <div className="text-sm flex flex-col items-end gap-1">
+                <div>Remaining: <b>${p.remaining.toFixed(2)}</b> / ${p.total.toFixed(2)}</div>
+                <label className="text-xs flex items-center gap-1">
+                  <input type="checkbox"
+                    checked={isReminderEnabled(p.id)}
+                    onChange={e=>setReminderEnabled(p.id, e.target.checked)}
+                  />
+                  Remind me
+                </label>
+              </div>
             </div>
             <div className="mt-3 flex flex-wrap gap-2">
               {p.dueDates.map(d => (

--- a/src/components/modals/ManageObligationsModal.tsx
+++ b/src/components/modals/ManageObligationsModal.tsx
@@ -3,6 +3,7 @@ import Modal from '../Modal';
 import Button from '../Button';
 import ObligationModal from './ObligationModal';
 import type { Obligation } from '../../types';
+import { isReminderEnabled, setReminderEnabled } from '../../utils/notifications';
 
 export default function ManageObligationsModal({
   open, onClose, obligations, onChange
@@ -28,6 +29,7 @@ export default function ManageObligationsModal({
               <th className="py-2 pr-4">Amount</th>
               <th className="py-2 pr-4">Cadence</th>
               <th className="py-2 pr-4">Due</th>
+              <th className="py-2 pr-4">Remind</th>
               <th className="py-2 pr-4">Actions</th>
             </tr>
           </thead>
@@ -38,6 +40,11 @@ export default function ManageObligationsModal({
                 <td className="py-2 pr-4">${o.amount.toFixed(2)}</td>
                 <td className="py-2 pr-4">{o.cadence}</td>
                 <td className="py-2 pr-4">{o.dueDate || '—'}</td>
+                <td className="py-2 pr-4">
+                  {o.dueDate ? (
+                    <input type="checkbox" checked={isReminderEnabled(o.id)} onChange={e=>setReminderEnabled(o.id, e.target.checked)} />
+                  ) : '—'}
+                </td>
                 <td className="py-2 pr-4">
                   <div className="flex gap-2">
                     <Button variant="secondary" onClick={() => setEditing(o)}>Edit</Button>

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,5 +1,6 @@
 import jsPDF from 'jspdf';
 import { Parser } from 'json2csv';
+import type { BNPLPlan, Obligation } from '../types';
 
 export function exportJSON(filename: string, data: unknown) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -24,6 +25,38 @@ export function exportPDF(filename: string, text: string) {
   const lines = doc.splitTextToSize(text, maxWidth);
   doc.text(lines, margin, margin);
   doc.save(filename);
+}
+
+export function exportICS(filename: string, plans: BNPLPlan[], obligations: Obligation[]) {
+  const lines: string[] = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Project Thrive//EN'
+  ];
+  plans.forEach(p => {
+    p.dueDates.forEach(d => {
+      lines.push(
+        'BEGIN:VEVENT',
+        `UID:${p.id}-${d}@project-thrive`,
+        `SUMMARY:${p.provider} payment due`,
+        `DTSTART;VALUE=DATE:${d.replace(/-/g, '')}`,
+        'END:VEVENT'
+      );
+    });
+  });
+  obligations.forEach(o => {
+    if (!o.dueDate) return;
+    lines.push(
+      'BEGIN:VEVENT',
+      `UID:obl-${o.id}@project-thrive`,
+      `SUMMARY:${o.name} due`,
+      `DTSTART;VALUE=DATE:${o.dueDate.replace(/-/g, '')}`,
+      'END:VEVENT'
+    );
+  });
+  lines.push('END:VCALENDAR');
+  const blob = new Blob([lines.join('\r\n')], { type: 'text/calendar' });
+  triggerDownload(filename, blob);
 }
 
 function triggerDownload(filename: string, blob: Blob) {

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,90 @@
+import type { BNPLPlan, Obligation } from '../types';
+
+const KEY_PREFIX = 'reminder:';
+
+export function isReminderEnabled(id: string): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem(KEY_PREFIX + id) === '1';
+}
+
+export function setReminderEnabled(id: string, enabled: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  if (enabled) localStorage.setItem(KEY_PREFIX + id, '1');
+  else localStorage.removeItem(KEY_PREFIX + id);
+}
+
+interface ReminderItem {
+  id: string;
+  title: string;
+  due: string;
+}
+
+function collectDueToday(plans: BNPLPlan[], obligations: Obligation[]): ReminderItem[] {
+  const items: ReminderItem[] = [];
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const end = new Date(start.getTime() + 86400000);
+
+  plans.forEach(p => {
+    if (!isReminderEnabled(p.id)) return;
+    p.dueDates.forEach(d => {
+      const dd = new Date(d + 'T00:00:00');
+      if (dd >= start && dd < end) {
+        items.push({ id: `${p.id}-${d}`, title: `${p.provider} payment`, due: d });
+      }
+    });
+  });
+
+  obligations.forEach(o => {
+    if (!o.dueDate) return;
+    if (!isReminderEnabled(o.id)) return;
+    const dd = new Date(o.dueDate + 'T00:00:00');
+    if (dd >= start && dd < end) {
+      items.push({ id: `obl-${o.id}`, title: `${o.name} due`, due: o.dueDate });
+    }
+  });
+
+  return items;
+}
+
+async function notify(items: ReminderItem[]) {
+  if (!items.length) return;
+  if (!('Notification' in window)) return;
+  const perm = await Notification.requestPermission();
+  if (perm !== 'granted') return;
+
+  if ('serviceWorker' in navigator) {
+    try {
+      await navigator.serviceWorker.register('/sw.js');
+      const reg = await navigator.serviceWorker.ready;
+      reg.active?.postMessage({ type: 'schedule', items });
+      return;
+    } catch {
+      // fall through to direct notifications
+    }
+  }
+
+  items.forEach(i => new Notification(i.title, { body: `Due ${i.due}` }));
+}
+
+let timer: number | undefined;
+
+export function startDailyChecks(plans: BNPLPlan[], obligations: Obligation[]): void {
+  if (timer) clearTimeout(timer);
+  notify(collectDueToday(plans, obligations));
+
+  const now = new Date();
+  const next = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  timer = window.setTimeout(() => startDailyChecks(plans, obligations), next.getTime() - now.getTime());
+}
+
+export function collectCalendarItems(plans: BNPLPlan[], obligations: Obligation[]) {
+  const items: { title: string; date: string; }[] = [];
+  plans.forEach(p => {
+    p.dueDates.forEach(d => items.push({ title: `${p.provider} payment`, date: d }));
+  });
+  obligations.forEach(o => {
+    if (o.dueDate) items.push({ title: o.name, date: o.dueDate });
+  });
+  return items;
+}


### PR DESCRIPTION
## Summary
- add notification utility to check due dates and schedule browser push alerts
- enable reminder toggles for BNPL plans and obligations
- expose optional calendar export with .ics file

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7f566a908331bc3c7ea066acce1b