### PR TITLE
Refactor import flow and add transaction support

### DIFF
--- a/src/components/modals/ImportDataModal.tsx
+++ b/src/components/modals/ImportDataModal.tsx
@@ -2,17 +2,27 @@ import React, { useState } from 'react';
 import Modal from '../Modal';
 import Button from '../Button';
 import { importSchema, type ImportPayload } from '../../schema/import';
+import type { Budget, Transaction } from '../../types';
 export type { ImportPayload } from '../../schema/import';
 
 export default function ImportDataModal({
-  open, onClose, onImport
+  open,
+  onClose,
+  onImport,
+  budgets,
+  onTransactions,
 }: {
   open: boolean;
   onClose: () => void;
   onImport: (payload: ImportPayload) => void;
+  budgets: Budget[];
+  onTransactions?: (txns: Transaction[]) => void;
 }) {
   const [text, setText] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  // budgets are currently unused but may support transaction category mapping in the future
+  void budgets;
 
   async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0];
@@ -31,6 +41,9 @@ export default function ImportDataModal({
         return;
       }
       onImport(result.data);
+      if (onTransactions && result.data.transactions) {
+        onTransactions(result.data.transactions);
+      }
       onClose();
     } catch (e) {
       setError('Invalid JSON: ' + (e instanceof Error ? e.message : String(e)));

--- a/src/schema/import.ts
+++ b/src/schema/import.ts
@@ -42,12 +42,31 @@ const goalSchema = z.object({
   priority: z.number().optional()
 });
 
+const obligationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  amount: z.number(),
+  cadence: z.enum(['weekly', 'biweekly', 'monthly', 'quarterly', 'yearly']),
+  dueDate: z.string().optional()
+});
+
+const transactionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(['income', 'expense']),
+  amount: z.number(),
+  date: z.string(),
+  category: z.string().optional()
+});
+
 export const importSchema = z.object({
   budgets: z.array(budgetSchema),
   debts: z.array(debtSchema),
   bnpl: z.array(bnplPlanSchema),
   recurring: z.array(recurringTransactionSchema),
-  goals: z.array(goalSchema)
+  goals: z.array(goalSchema),
+  obligations: z.array(obligationSchema).optional(),
+  transactions: z.array(transactionSchema).optional()
 });
 
 export type ImportPayload = z.infer<typeof importSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,4 +71,6 @@ export interface ImportPayload {
   bnpl: BNPLPlan[];
   recurring: RecurringTransaction[];
   goals: Goal[];
+  obligations?: Obligation[];
+  transactions?: Transaction[];
 }


### PR DESCRIPTION
## Summary
- add obligations and transactions to import schema and payload types
- wire ImportDataModal with budgets and transaction callback
- use handle*Change functions for imported data updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae849745c48331ad78b3682ec039e0