### PR TITLE
feat: persist notifications across service worker restarts

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,67 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+const DB_NAME = 'notification-db';
+const STORE_NAME = 'notifications';
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onerror = () => reject(request.error);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+  });
+}
+
+async function addNotification(data) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.objectStore(STORE_NAME).add(data);
+  });
+}
+
+async function getDueNotifications() {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => {
+      const now = Date.now();
+      const all = request.result;
+      const due = all.filter((n) => n.timestamp <= now);
+      due.forEach((n) => store.delete(n.id));
+      resolve(due);
+    };
+  });
+}
+
+async function showDueNotifications() {
+  const due = await getDueNotifications();
+  for (const note of due) {
+    await self.registration.showNotification(note.title, note.options || {});
+  }
+}
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'schedule') {
+    event.waitUntil(addNotification(event.data.payload));
+  }
+});
+
+self.addEventListener('periodicsync', (event) => {
+  if (event.tag === 'notification-sync') {
+    event.waitUntil(showDueNotifications());
+  }
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,33 @@ import { Toaster } from 'react-hot-toast';
 import ErrorBoundary from './components/ErrorBoundary';
 import { registerSW } from 'virtual:pwa-register';
 
-registerSW();
+function rescheduleNotifications(reg: ServiceWorkerRegistration) {
+  // Re-register periodic background sync and resend pending notifications.
+  if ('periodicSync' in reg) {
+    reg.periodicSync
+      .register('notification-sync', { minInterval: 60 * 60 * 1000 })
+      .catch(() => {
+        /* periodic sync may be unavailable */
+      });
+  }
+
+  const pending = JSON.parse(
+    localStorage.getItem('pending-notifications') || '[]'
+  );
+  for (const note of pending) {
+    reg.active?.postMessage({ type: 'schedule', payload: note });
+  }
+}
+
+registerSW({
+  onRegistered(reg) {
+    if (reg) rescheduleNotifications(reg);
+  }
+});
+
+navigator.serviceWorker.addEventListener('controllerchange', () => {
+  navigator.serviceWorker.ready.then((reg) => rescheduleNotifications(reg));
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add service worker logic to store notifications and trigger them via periodic background sync
- reschedule periodic sync and pending notifications when the service worker is registered or reactivated

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae860148f88331889a9d8cff115da8