### PR TITLE
Check notification permission before requesting

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,6 @@
+export async function requestNotificationPermission() {
+  if (!('Notification' in window)) return;
+  if (Notification.permission === 'default') {
+    await Notification.requestPermission();
+  }
+}


### PR DESCRIPTION
## Summary
- request notification permission only when the browser's status is "default"

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ae85ffaa2883318f48b858f8431281