### PR TITLE
chore: ensure directory ignores have trailing slashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Ignore build and coverage directories
 node_modules/
 dist/
 coverage/


### PR DESCRIPTION
## Summary
- comment `.gitignore` and ensure directory patterns use trailing slashes

## Testing
- `npm test` *(fails: Cannot find package 'vite-plugin-pwa')*

------
https://chatgpt.com/codex/tasks/task_e_68ae85f702608331a983a85bbb52252d