### PR TITLE
feat: add ICS export option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import CalculatorModal from './components/modals/CalculatorModal';
 import { payoff } from './logic/debt';
 import { evaluateBadges } from './logic/badges';
 import { SEEDED } from './utils/constants';
-import { exportJSON, exportCSV, exportPDF, exportCSVBudgets } from './utils/export';
+import { exportJSON, exportCSV, exportPDF, exportCSVBudgets, exportICS } from './utils/export';
 import toast from 'react-hot-toast';
 import { Budget, Goal, RecurringTransaction, Obligation, Debt, BNPLPlan } from './types';
 
@@ -203,7 +203,7 @@ export default function App(){
     );
   }
 
-  function handleExport(kind: 'json'|'csv'|'pdf') {
+  function handleExport(kind: 'json'|'csv'|'pdf'|'ics') {
     const payload = { budgets, recurring, goals, debts, bnpl };
     if (kind === 'json') exportJSON('chatpay-data.json', payload);
     if (kind === 'csv') exportCSVBudgets('chatpay-budgets.csv', budgets);
@@ -215,6 +215,7 @@ export default function App(){
       'Debts: ' + debts.length + '\n' +
       'BNPL: ' + bnpl.length + '\n'
     );
+    if (kind === 'ics') exportICS('chatpay-events.ics', bnpl, obligations);
   }
 
   function handleImport(payload: ImportPayload) {
@@ -253,6 +254,7 @@ export default function App(){
             <Button variant="secondary" onClick={()=>handleExport('json')}>Export JSON</Button>
             <Button variant="secondary" onClick={()=>handleExport('csv')}>CSV</Button>
             <Button variant="secondary" onClick={()=>handleExport('pdf')}>PDF</Button>
+            <Button variant="secondary" onClick={()=>handleExport('ics')}>ICS</Button>
             <Button variant="secondary" onClick={()=>setToken(null)}>Logout</Button>
             <ThemeToggle />
           </div>


### PR DESCRIPTION
## Summary
- support exporting plans and obligations to iCalendar format
- expose Export ICS action in the application header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae860237f08331b53f273dc041e9fd