### PR TITLE
fix notification permission handling in notify

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -4,3 +4,16 @@ export async function requestNotificationPermission() {
     await Notification.requestPermission();
   }
 }
+
+export async function notify(title: string, options?: NotificationOptions) {
+  if (!('Notification' in window)) return;
+
+  if (Notification.permission === 'denied') return;
+
+  if (Notification.permission === 'default') {
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') return;
+  }
+
+  new Notification(title, options);
+}


### PR DESCRIPTION
## Summary
- add `notify` helper that checks Notification.permission and only requests permission when needed
- skip showing notifications if permission is denied

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae8822cba08331a7efeb5f55cf0fc1