### PR TITLE
feat: add ICS export option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import CalculatorModal from './components/modals/CalculatorModal';
 import { payoff } from './logic/debt';
 import { evaluateBadges } from './logic/badges';
 import { SEEDED } from './utils/constants';
-import { exportJSON, exportPDF, exportCSVBudgets } from './utils/export';
+import { exportJSON, exportPDF, exportCSVBudgets, exportICS } from './utils/export';
 import toast from 'react-hot-toast';
 import { Budget, Goal, RecurringTransaction, Obligation, Debt, BNPLPlan, Transaction } from './types';
 
@@ -207,8 +207,8 @@ export default function App(){
     );
   }
 
-  function handleExport(kind: 'json'|'csv'|'pdf') {
-    const payload = { budgets, recurring, goals, debts, bnpl };
+  function handleExport(kind: 'json'|'csv'|'pdf'|'ics') {
+    const payload = { budgets, recurring, goals, debts, bnpl, obligations };
     if (kind === 'json') exportJSON('chatpay-data.json', payload);
     if (kind === 'csv') exportCSVBudgets('chatpay-budgets.csv', budgets);
     if (kind === 'pdf') exportPDF('chatpay-summary.pdf',
@@ -219,6 +219,7 @@ export default function App(){
       'Debts: ' + debts.length + '\n' +
       'BNPL: ' + bnpl.length + '\n'
     );
+    if (kind === 'ics') exportICS('chatpay-schedule.ics', bnpl, obligations);
   }
 
   function handleImport(payload: ImportPayload) {
@@ -260,6 +261,7 @@ export default function App(){
             <Button variant="secondary" onClick={()=>handleExport('json')}>Export JSON</Button>
             <Button variant="secondary" onClick={()=>handleExport('csv')}>CSV</Button>
             <Button variant="secondary" onClick={()=>handleExport('pdf')}>PDF</Button>
+            <Button variant="secondary" onClick={()=>handleExport('ics')}>ICS</Button>
             <Button variant="secondary" onClick={()=>setToken(null)}>Logout</Button>
             <ThemeToggle />
           </div>

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,5 +1,6 @@
 import jsPDF from 'jspdf';
 import { Parser } from 'json2csv';
+import type { BNPLPlan, Obligation } from '../types';
 
 export function exportJSON(filename: string, data: unknown) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -24,6 +25,41 @@ export function exportPDF(filename: string, text: string) {
   const lines = doc.splitTextToSize(text, maxWidth);
   doc.text(lines, margin, margin);
   doc.save(filename);
+}
+
+export function exportICS(filename: string, bnpl: BNPLPlan[], obligations: Obligation[]) {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const fmt = (iso: string) => {
+    const d = new Date(iso);
+    return (
+      d.getUTCFullYear().toString() +
+      pad(d.getUTCMonth() + 1) +
+      pad(d.getUTCDate()) +
+      'T' +
+      pad(d.getUTCHours()) +
+      pad(d.getUTCMinutes()) +
+      pad(d.getUTCSeconds()) +
+      'Z'
+    );
+  };
+  const events: string[] = [];
+  bnpl.forEach((plan) => {
+    plan.dueDates.forEach((date, i) => {
+      events.push(
+        ['BEGIN:VEVENT', `UID:bnpl-${plan.id}-${i}@chatpay`, `SUMMARY:${plan.description} payment`, `DTSTART:${fmt(date)}`, 'END:VEVENT'].join('\n')
+      );
+    });
+  });
+  obligations.forEach((o) => {
+    if (o.dueDate) {
+      events.push(
+        ['BEGIN:VEVENT', `UID:obl-${o.id}@chatpay`, `SUMMARY:${o.name}`, `DTSTART:${fmt(o.dueDate)}`, 'END:VEVENT'].join('\n')
+      );
+    }
+  });
+  const ics = ['BEGIN:VCALENDAR', 'VERSION:2.0', ...events, 'END:VCALENDAR'].join('\n');
+  const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
+  triggerDownload(filename, blob);
 }
 
 function triggerDownload(filename: string, blob: Blob) {


### PR DESCRIPTION
## Summary
- add exportICS utility to generate calendar files for BNPL plans and obligations
- hook up Export ICS button in App header

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae88253c6c83318395a52aa7033a1a