### PR TITLE
Move logic tests into __tests__

### DIFF
--- a/src/logic/__tests__/badges.test.ts
+++ b/src/logic/__tests__/badges.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { evaluateBadges } from './badges';
-import type { PlanStep } from './debt';
+import { evaluateBadges } from '../badges';
+import type { PlanStep } from '../debt';
 
 const makeStep = (balances: Record<string, number>): PlanStep => ({
   month: 0,

--- a/src/logic/__tests__/debt.test.ts
+++ b/src/logic/__tests__/debt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { payoff } from './debt';
+import { payoff } from '../debt';
 
 describe('payoff()', () => {
   it('pays off two debts and decreases interest over time', () => {


### PR DESCRIPTION
## Summary
- relocate `badges.test.ts` and `debt.test.ts` into `src/logic/__tests__`
- fix relative imports after move

## Testing
- `npm test src/logic/__tests__`
- `npm test` *(fails: Error: Failed to load url @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae908017bc8331b6bb0fb93ad2587f