### PR TITLE
refactor: use express.json instead of body-parser

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
-const bodyParser = require('body-parser');
 const { Store } = require('./persistence');
 const { makeToken, verifyToken } = require('./utils/jwt');
 
@@ -29,7 +28,7 @@ app.use(cors({
   credentials: true
 }));
 
-app.use(bodyParser.json({ limit: '1mb' }));
+app.use(express.json({ limit: '1mb' }));
 
 // Auth middleware
 function auth(req, res, next) {


### PR DESCRIPTION
## Summary
- replace body-parser with express.json in server

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68ae907db3e88331b18c5dd4829458ba