### PR TITLE
fix: use commonjs for server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,13 +1,12 @@
 {
   "name": "thrive-server",
   "version": "1.0.0",
-  "type": "module",
+  "type": "commonjs",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"
   },
   "dependencies": {
-    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2"


### PR DESCRIPTION
## Summary
- configure the server package to use CommonJS
- remove unused bcryptjs dependency

## Testing
- `npm test` *(fails: Error: Failed to load url @playwright/test (resolved id: @playwright/test))*

------
https://chatgpt.com/codex/tasks/task_e_68ae907c333483319e1011a228b252ba