### PR TITLE
Pause API health checks when tab hidden

### DIFF
--- a/src/hooks/__tests__/useApiHealth.test.tsx
+++ b/src/hooks/__tests__/useApiHealth.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { useApiHealth } from '../useApiHealth';
+
+const TestComponent = () => {
+  useApiHealth('http://example.com', 1000);
+  return null;
+};
+
+describe('useApiHealth visibility handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // @ts-ignore
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
+
+  it('stops pinging when document is hidden', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() => { root.render(<TestComponent />); });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => { vi.advanceTimersByTime(1000); });
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    Object.defineProperty(document, 'hidden', { value: true });
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+
+    await act(async () => { vi.advanceTimersByTime(3000); });
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    Object.defineProperty(document, 'hidden', { value: false });
+    act(() => { document.dispatchEvent(new Event('visibilitychange')); });
+    await act(async () => { vi.advanceTimersByTime(0); });
+    expect(fetch).toHaveBeenCalledTimes(3);
+
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- Pause API health polling when the tab is hidden and resume on visibility
- Add tests verifying network requests stop while hidden

## Testing
- `npx vitest run src/hooks/__tests__/useApiHealth.test.tsx`
- `npm test` *(fails: Error: Failed to load url @playwright/test in tests/smoke.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ae933dd6608331b718ffa9c23c967b