### PR TITLE
feat: consolidate remote data fetching

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -115,6 +115,17 @@ function listRouter(key) {
   return router;
 }
 
+app.get('/api/data', auth, (req, res) => {
+  const user = store.getUser(req.user.email);
+  res.json({
+    budgets: user.budgets || [],
+    goals: user.goals || [],
+    debts: user.debts || [],
+    obligations: user.obligations || [],
+    bnpl: user.bnpl || [],
+  });
+});
+
 app.use('/api/budgets', listRouter('budgets'));
 app.use('/api/debts', listRouter('debts'));
 app.use('/api/goals', listRouter('goals'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import ThemeToggle from './components/ThemeToggle';
 import CommandPalette from './components/CommandPalette';
 import ApiStatusBanner from './components/system/ApiStatusBanner';
 import useHotkeys from './hooks/useHotkeys';
-import useRemoteList from './hooks/useRemoteList';
+import useRemoteData from './hooks/useRemoteData';
 import BudgetTracker from './components/BudgetTracker';
 import CashFlowProjection from './components/CashFlowProjection';
 import BNPLTrackerModal from './components/BNPLTrackerModal';
@@ -20,7 +20,7 @@ import { evaluateBadges } from './logic/badges';
 import { SEEDED } from './utils/constants';
 import { exportJSON, exportPDF, exportCSVBudgets, exportICS } from './utils/export';
 import toast from 'react-hot-toast';
-import { Budget, Goal, RecurringTransaction, Obligation, Debt, BNPLPlan, Transaction } from './types';
+import { Budget, Goal, RecurringTransaction, Obligation, Debt, Transaction } from './types';
 
 const DebtVelocityChart = React.lazy(() => import('./components/reports/DebtVelocityChart'));
 const SpendingHeatmap = React.lazy(() => import('./components/reports/SpendingHeatmap'));
@@ -37,11 +37,29 @@ export default function App(){
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const { list: budgets, create: addBudget, update: updateBudgetApi, remove: deleteBudgetApi } = useRemoteList<Budget>('budgets', token);
-  const { list: goals, setList: setGoals, create: addGoalApi, update: updateGoalApi, remove: deleteGoalApi } = useRemoteList<Goal>('goals', token);
-  const { list: debts, setList: setDebts, create: addDebtApi, update: updateDebtApi, remove: deleteDebtApi } = useRemoteList<Debt>('debts', token);
-  const { list: obligations, setList: setObligations, create: addObligationApi, update: updateObligationApi, remove: deleteObligationApi } = useRemoteList<Obligation>('obligations', token);
-  const { list: bnpl, create: addBnplApi } = useRemoteList<BNPLPlan>('bnpl', token);
+  const {
+    budgets,
+    addBudget,
+    updateBudgetApi,
+    deleteBudgetApi,
+    goals,
+    setGoals,
+    addGoalApi,
+    updateGoalApi,
+    deleteGoalApi,
+    debts,
+    setDebts,
+    addDebtApi,
+    updateDebtApi,
+    deleteDebtApi,
+    obligations,
+    setObligations,
+    addObligationApi,
+    updateObligationApi,
+    deleteObligationApi,
+    bnpl,
+    addBnplApi,
+  } = useRemoteData(token);
   const [recurring, setRecurring] = useState<RecurringTransaction[]>(() => SEEDED.recurring);
 
   const [paletteOpen, setPaletteOpen] = useState(false);

--- a/src/hooks/useRemoteData.ts
+++ b/src/hooks/useRemoteData.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Budget, Goal, Debt, Obligation, BNPLPlan } from '../types';
+
+const API = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export default function useRemoteData(token: string | null) {
+  const [budgets, setBudgets] = useState<Budget[]>([]);
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [debts, setDebts] = useState<Debt[]>([]);
+  const [obligations, setObligations] = useState<Obligation[]>([]);
+  const [bnpl, setBnpl] = useState<BNPLPlan[]>([]);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`${API}/data`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        setBudgets(data.budgets || []);
+        setGoals(data.goals || []);
+        setDebts(data.debts || []);
+        setObligations(data.obligations || []);
+        setBnpl(data.bnpl || []);
+      })
+      .catch(() => {
+        setBudgets([]);
+        setGoals([]);
+        setDebts([]);
+        setObligations([]);
+        setBnpl([]);
+      });
+  }, [token]);
+
+  function crud<T extends { id: string }>(
+    path: string,
+    setList: React.Dispatch<React.SetStateAction<T[]>>
+  ) {
+    const create = useCallback(
+      async (item: T) => {
+        if (!token) return;
+        const res = await fetch(`${API}/${path}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(item),
+        });
+        const data = await res.json();
+        setList((prev) => [...prev, data]);
+      },
+      [path, token]
+    );
+
+    const update = useCallback(
+      async (item: T) => {
+        if (!token) return;
+        await fetch(`${API}/${path}/${item.id}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(item),
+        });
+        setList((prev) => prev.map((x) => (x.id === item.id ? item : x)));
+      },
+      [path, token]
+    );
+
+    const remove = useCallback(
+      async (id: string) => {
+        if (!token) return;
+        await fetch(`${API}/${path}/${id}`, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setList((prev) => prev.filter((x) => x.id !== id));
+      },
+      [path, token]
+    );
+
+    return { create, update, remove } as const;
+  }
+
+  const budgetOps = crud<Budget>('budgets', setBudgets);
+  const goalOps = crud<Goal>('goals', setGoals);
+  const debtOps = crud<Debt>('debts', setDebts);
+  const obligationOps = crud<Obligation>('obligations', setObligations);
+  const bnplOps = crud<BNPLPlan>('bnpl', setBnpl);
+
+  return {
+    budgets,
+    setBudgets,
+    addBudget: budgetOps.create,
+    updateBudgetApi: budgetOps.update,
+    deleteBudgetApi: budgetOps.remove,
+    goals,
+    setGoals,
+    addGoalApi: goalOps.create,
+    updateGoalApi: goalOps.update,
+    deleteGoalApi: goalOps.remove,
+    debts,
+    setDebts,
+    addDebtApi: debtOps.create,
+    updateDebtApi: debtOps.update,
+    deleteDebtApi: debtOps.remove,
+    obligations,
+    setObligations,
+    addObligationApi: obligationOps.create,
+    updateObligationApi: obligationOps.update,
+    deleteObligationApi: obligationOps.remove,
+    bnpl,
+    setBnpl,
+    addBnplApi: bnplOps.create,
+    updateBnplApi: bnplOps.update,
+    deleteBnplApi: bnplOps.remove,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- add `/api/data` endpoint to return all user lists in one payload
- create `useRemoteData` hook to fetch aggregated data and provide CRUD helpers
- replace multiple `useRemoteList` hooks in `App` with consolidated state from `useRemoteData`

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint` *(fails: Require statement not part of import statement, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68ae933cb7288331a2d97d01800c074a