### PR TITLE
feat: debounce persistence saves

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -88,7 +88,7 @@ function listRouter(key) {
     const item = { id: req.body.id || String(Date.now()), ...req.body };
     user[key] = user[key] || [];
     user[key].push(item);
-    await store.save();
+    store.save();
     res.status(201).json(item);
   });
   // Update
@@ -99,7 +99,7 @@ function listRouter(key) {
     const idx = arr.findIndex(x => String(x.id) === String(id));
     if (idx === -1) return res.status(404).json({ error: 'not found' });
     arr[idx] = { ...arr[idx], ...req.body, id };
-    await store.save();
+    store.save();
     res.json(arr[idx]);
   });
   // Delete
@@ -109,7 +109,7 @@ function listRouter(key) {
     const arr = user[key] || [];
     const next = arr.filter(x => String(x.id) !== String(id));
     user[key] = next;
-    await store.save();
+    store.save();
     res.status(204).end();
   });
   return router;

--- a/tests/persistence.spec.ts
+++ b/tests/persistence.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Store } from '../server/persistence.js';
+
+describe('Store.save', () => {
+  it('coalesces rapid save calls into a single write', async () => {
+    vi.useFakeTimers();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'store-'));
+    const store = new Store({ dataDir: dir });
+
+    const writeSpy = vi.fn().mockResolvedValue(undefined);
+    // @ts-ignore allow test to override internal method
+    store._writeToDisk = writeSpy;
+
+    const p1 = store.save();
+    const p2 = store.save();
+    const p3 = store.save();
+
+    expect(p1).toBe(p2);
+    expect(p1).toBe(p3);
+
+    vi.advanceTimersByTime(500);
+    await p1;
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- debounce Store.save to batch writes and queue sequentially
- call save non-blocking in list routes
- test that rapid saves coalesce into a single disk write

## Testing
- `npx vitest tests/persistence.spec.ts`
- `npm test` *(fails: Failed to load url @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68ae933ba1c48331ad6c74024e5a2609