### PR TITLE
Compute DTEND for ICS exports

### DIFF
--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -42,18 +42,42 @@ export function exportICS(filename: string, bnpl: BNPLPlan[], obligations: Oblig
       'Z'
     );
   };
+  const fmtDate = (d: Date) =>
+    d.getUTCFullYear().toString() + pad(d.getUTCMonth() + 1) + pad(d.getUTCDate());
   const events: string[] = [];
   bnpl.forEach((plan) => {
     plan.dueDates.forEach((date, i) => {
+      const startDate = new Date(date);
+      const endDate = new Date(startDate);
+      endDate.setUTCDate(startDate.getUTCDate() + 1);
+      const endStr = fmtDate(endDate);
       events.push(
-        ['BEGIN:VEVENT', `UID:bnpl-${plan.id}-${i}@chatpay`, `SUMMARY:${plan.description} payment`, `DTSTART:${fmt(date)}`, 'END:VEVENT'].join('\n')
+        [
+          'BEGIN:VEVENT',
+          `UID:bnpl-${plan.id}-${i}@chatpay`,
+          `SUMMARY:${plan.description} payment`,
+          `DTSTART:${fmt(date)}`,
+          `DTEND:${endStr}`,
+          'END:VEVENT',
+        ].join('\n')
       );
     });
   });
   obligations.forEach((o) => {
     if (o.dueDate) {
+      const startDate = new Date(o.dueDate);
+      const endDate = new Date(startDate);
+      endDate.setUTCDate(startDate.getUTCDate() + 1);
+      const endStr = fmtDate(endDate);
       events.push(
-        ['BEGIN:VEVENT', `UID:obl-${o.id}@chatpay`, `SUMMARY:${o.name}`, `DTSTART:${fmt(o.dueDate)}`, 'END:VEVENT'].join('\n')
+        [
+          'BEGIN:VEVENT',
+          `UID:obl-${o.id}@chatpay`,
+          `SUMMARY:${o.name}`,
+          `DTSTART:${fmt(o.dueDate)}`,
+          `DTEND:${endStr}`,
+          'END:VEVENT',
+        ].join('\n')
       );
     }
   });


### PR DESCRIPTION
## Summary
- add `DTEND` line to BNPL and obligation events in `exportICS`
- compute end date one day after start and format as `YYYYMMDD`

## Testing
- `npm test` *(fails: Error: Failed to load url @playwright/test in tests/smoke.spec.ts)*
- `npm run lint` *(fails: 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaf0c89f48331bc0e9cf33560e196