### PR TITLE
Add ICS export test and fix ICS formatting

### DIFF
--- a/src/utils/export.spec.ts
+++ b/src/utils/export.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { exportICS } from './export';
+import type { BNPLPlan, Obligation } from '../types';
+
+describe('exportICS', () => {
+  it('creates an ICS file with events and CRLF line endings', async () => {
+    const bnpl: BNPLPlan[] = [
+      {
+        id: 'p1',
+        provider: 'Affirm',
+        description: 'Laptop',
+        total: 1000,
+        remaining: 0,
+        dueDates: ['2024-08-01T00:00:00Z'],
+      },
+    ];
+    const obligations: Obligation[] = [
+      {
+        id: 'o1',
+        name: 'Gym',
+        amount: 50,
+        cadence: 'monthly',
+        dueDate: '2024-08-05T00:00:00Z',
+      },
+    ];
+
+    let text = '';
+    const mock = vi.fn((_: string, blob: Blob) => blob.text().then((t) => { text = t; }));
+
+    exportICS('test.ics', bnpl, obligations, mock);
+    await mock.mock.results[0].value;
+
+    expect(text).toContain('BEGIN:VCALENDAR');
+    expect(text).toMatch(/BEGIN:VEVENT/);
+    expect(text).toMatch(/DTSTAMP:\d{8}T\d{6}Z/);
+    expect(text).toMatch(/RRULE:FREQ=MONTHLY/);
+    expect(text).toMatch(/\r\n/);
+    expect(text).not.toMatch(/(?<!\r)\n/);
+  });
+});

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -27,7 +27,12 @@ export function exportPDF(filename: string, text: string) {
   doc.save(filename);
 }
 
-export function exportICS(filename: string, bnpl: BNPLPlan[], obligations: Obligation[]) {
+export function exportICS(
+  filename: string,
+  bnpl: BNPLPlan[],
+  obligations: Obligation[],
+  download: (filename: string, blob: Blob) => void = triggerDownload
+) {
   const pad = (n: number) => String(n).padStart(2, '0');
   const fmt = (iso: string) => {
     const d = new Date(iso);
@@ -42,27 +47,60 @@ export function exportICS(filename: string, bnpl: BNPLPlan[], obligations: Oblig
       'Z'
     );
   };
+  const newline = '\r\n';
+  const now = fmt(new Date().toISOString());
+  const freq = (cadence: Obligation['cadence']) => {
+    switch (cadence) {
+      case 'weekly':
+        return 'FREQ=WEEKLY';
+      case 'biweekly':
+        return 'FREQ=WEEKLY;INTERVAL=2';
+      case 'monthly':
+        return 'FREQ=MONTHLY';
+      case 'quarterly':
+        return 'FREQ=MONTHLY;INTERVAL=3';
+      case 'yearly':
+        return 'FREQ=YEARLY';
+      default:
+        return '';
+    }
+  };
   const events: string[] = [];
   bnpl.forEach((plan) => {
     plan.dueDates.forEach((date, i) => {
       events.push(
-        ['BEGIN:VEVENT', `UID:bnpl-${plan.id}-${i}@chatpay`, `SUMMARY:${plan.description} payment`, `DTSTART:${fmt(date)}`, 'END:VEVENT'].join('\n')
+        [
+          'BEGIN:VEVENT',
+          `UID:bnpl-${plan.id}-${i}@chatpay`,
+          `SUMMARY:${plan.description} payment`,
+          `DTSTAMP:${now}`,
+          `DTSTART:${fmt(date)}`,
+          'END:VEVENT',
+        ].join(newline)
       );
     });
   });
   obligations.forEach((o) => {
     if (o.dueDate) {
       events.push(
-        ['BEGIN:VEVENT', `UID:obl-${o.id}@chatpay`, `SUMMARY:${o.name}`, `DTSTART:${fmt(o.dueDate)}`, 'END:VEVENT'].join('\n')
+        [
+          'BEGIN:VEVENT',
+          `UID:obl-${o.id}@chatpay`,
+          `SUMMARY:${o.name}`,
+          `DTSTAMP:${now}`,
+          `DTSTART:${fmt(o.dueDate)}`,
+          `RRULE:${freq(o.cadence)}`,
+          'END:VEVENT',
+        ].join(newline)
       );
     }
   });
-  const ics = ['BEGIN:VCALENDAR', 'VERSION:2.0', ...events, 'END:VCALENDAR'].join('\n');
+  const ics = ['BEGIN:VCALENDAR', 'VERSION:2.0', ...events, 'END:VCALENDAR'].join(newline);
   const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' });
-  triggerDownload(filename, blob);
+  download(filename, blob);
 }
 
-function triggerDownload(filename: string, blob: Blob) {
+export let triggerDownload = (filename: string, blob: Blob) => {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
@@ -70,4 +108,4 @@ function triggerDownload(filename: string, blob: Blob) {
   a.rel = 'noopener';
   a.click();
   setTimeout(() => URL.revokeObjectURL(url), 1000);
-}
+};


### PR DESCRIPTION
## Summary
- allow injecting download function into `exportICS`
- include `DTSTAMP` and `RRULE` fields and CRLF line endings in ICS output
- add unit test for ICS export

## Testing
- `npm test src/utils/export.spec.ts`
- `npm test` *(fails: Failed to load url @playwright/test in tests/smoke.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aeaf0fad548331b62fd81f7b1ac42f