### PR TITLE
feat: trap focus inside modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -15,11 +15,37 @@ export default function Modal({
 
   useEffect(() => {
     if (!open) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+
+    const focusable = ref.current
+      ? Array.from(
+          ref.current.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          )
+        )
+      : [];
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'Tab' && focusable.length) {
+        const active = document.activeElement as HTMLElement | null;
+        if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first?.focus();
+        } else if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last?.focus();
+        }
+      }
+    };
+
     if (typeof window !== 'undefined') {
       window.addEventListener('keydown', onKey);
     }
-    setTimeout(() => ref.current?.querySelector<HTMLElement>('button, [href], input, select, textarea')?.focus(), 0);
+
+    setTimeout(() => first?.focus(), 0);
+
     return () => {
       if (typeof window !== 'undefined') {
         window.removeEventListener('keydown', onKey);


### PR DESCRIPTION
## Summary
- trap focus within modal by cycling Tab and Shift+Tab
- compute focusable elements and focus first when opened
- clean up keydown handler on close

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint` *(fails: 18 problems (18 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b0f9d8dc1083318e457b11709d87bd