### PR TITLE
Guard controllerchange listener with serviceWorker check

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,50 +1,52 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import './index.css';
-import { Toaster } from 'react-hot-toast';
-import ErrorBoundary from './components/ErrorBoundary';
-import { registerSW } from 'virtual:pwa-register';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+import { Toaster } from "react-hot-toast";
+import ErrorBoundary from "./components/ErrorBoundary";
+import { registerSW } from "virtual:pwa-register";
 
 function rescheduleNotifications(reg: ServiceWorkerRegistration) {
   // Re-register periodic background sync and resend pending notifications.
-  if ('periodicSync' in reg) {
+  if ("periodicSync" in reg) {
     reg.periodicSync
-      .register('notification-sync', { minInterval: 60 * 60 * 1000 })
+      .register("notification-sync", { minInterval: 60 * 60 * 1000 })
       .catch(() => {
         /* periodic sync may be unavailable */
       });
   }
 
   const pending = JSON.parse(
-    localStorage.getItem('pending-notifications') || '[]'
+    localStorage.getItem("pending-notifications") || "[]",
   );
   for (const note of pending) {
-    reg.active?.postMessage({ type: 'schedule', payload: note });
+    reg.active?.postMessage({ type: "schedule", payload: note });
   }
 }
 
 registerSW({
   onRegistered(reg) {
     if (reg) rescheduleNotifications(reg);
-  }
+  },
 });
 
-navigator.serviceWorker.addEventListener('controllerchange', () => {
-  navigator.serviceWorker.ready.then((reg) => rescheduleNotifications(reg));
-});
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.addEventListener("controllerchange", () => {
+    navigator.serviceWorker.ready.then((reg) => rescheduleNotifications(reg));
+  });
+}
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <App />
       <Toaster position="top-right" />
     </ErrorBoundary>
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(()=>{});
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch(() => {});
   });
 }


### PR DESCRIPTION
## Summary
- guard controllerchange listener behind `if ('serviceWorker' in navigator)`
- ensure service worker is ready before rescheduling notifications

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint` *(fails: 18 errors)*
- `npx prettier src/main.tsx -w`


------
https://chatgpt.com/codex/tasks/task_e_68b0f939ca3c8331a47047c43eae33e9