### PR TITLE
feat: allow overriding button type

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -4,6 +4,7 @@ export default function Button({
   children,
   className = '',
   variant = 'primary',
+  type = 'button',
   ...props
 }: React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: 'primary'|'secondary'|'danger' }) {
   const base = "px-4 py-2 rounded-lg font-semibold transition duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 min-h-[44px]";
@@ -12,5 +13,5 @@ export default function Button({
     : variant === 'danger'
     ? 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500'
     : 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500';
-  return <button className={`${base} ${variantClass} ${className}`} {...props}>{children}</button>;
+  return <button type={type} className={`${base} ${variantClass} ${className}`} {...props}>{children}</button>;
 }


### PR DESCRIPTION
## Summary
- add default `type="button"` to Button component props and forward it to the rendered element

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run build` *(fails: [vite-plugin-pwa:build] Rollup failed to resolve import "@/hooks/useApiHealth"...)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: multiple pre-existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f938fd1c8331a397e73e3f577723