### PR TITLE
restore focus to trigger element when modal closes

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -12,9 +12,11 @@ export default function Modal({
   children: React.ReactNode;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const previouslyFocused = useRef<Element | null>(null);
 
   useEffect(() => {
     if (!open) return;
+    previouslyFocused.current = typeof document !== 'undefined' ? document.activeElement : null;
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
     if (typeof window !== 'undefined') {
       window.addEventListener('keydown', onKey);
@@ -23,6 +25,10 @@ export default function Modal({
     return () => {
       if (typeof window !== 'undefined') {
         window.removeEventListener('keydown', onKey);
+      }
+      const el = previouslyFocused.current as HTMLElement | null;
+      if (el && typeof document !== 'undefined' && document.contains(el)) {
+        el.focus();
       }
     };
   }, [open, onClose]);


### PR DESCRIPTION
## Summary
- store currently focused element before opening modal and restore focus after closing

## Testing
- `npm test` (fails: Playwright test called in wrong context)
- `npm run lint` (fails: several lint errors across repo)


------
https://chatgpt.com/codex/tasks/task_e_68b0f9384fc883319e62d7e6d294000e