### PR TITLE
refactor: use button in API status banner

### DIFF
--- a/src/components/system/ApiStatusBanner.tsx
+++ b/src/components/system/ApiStatusBanner.tsx
@@ -14,13 +14,13 @@ export default function ApiStatusBanner() {
     <div className="w-full bg-yellow-500 text-black text-sm py-2 px-4">
       <div className="max-w-6xl mx-auto flex items-center justify-between">
         <span>Offline/local mode — {msg}. Some data may be cached only.</span>
-        <a
-          href=""
-          onClick={(e) => { e.preventDefault(); location.reload(); }}
-          className="underline"
+        <button
+          type="button"
+          onClick={() => location.reload()}
+          className="underline px-2 py-1 rounded"
         >
           Retry
-        </a>
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace retry anchor with button in ApiStatusBanner
- move reload logic to button click and remove link navigation

## Testing
- `npm run lint` *(fails: empty block statements, no-explicit-any, ban-ts-comment in other files)*
- `npm test` *(fails: Playwright test misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f937c8d483319207c2a9ba579ce7