### PR TITLE
Handle fetch errors and aborts in remote data hooks

### DIFF
--- a/src/hooks/useRemoteList.ts
+++ b/src/hooks/useRemoteList.ts
@@ -4,56 +4,106 @@ const API = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 
 export default function useRemoteList<T extends { id: string }>(path: string, token: string | null) {
   const [list, setList] = useState<T[]>([]);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     if (!token) return;
-    fetch(`${API}/${path}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-      .then((r) => r.json())
-      .then(setList)
-      .catch(() => setList([]));
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        const res = await fetch(`${API}/${path}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Failed to fetch ${path}: ${res.status} ${res.statusText}`);
+        }
+        const data = await res.json();
+        setList(data);
+        setError(null);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        console.error(err);
+        setError(err as Error);
+      }
+    };
+
+    load();
+
+    return () => controller.abort();
   }, [path, token]);
 
   const create = useCallback(async (item: T) => {
     if (!token) return;
-    const res = await fetch(`${API}/${path}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(item),
-    });
-    const data = await res.json();
-    setList((prev) => [...prev, data]);
+    try {
+      const res = await fetch(`${API}/${path}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(item),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to create ${path}`);
+      }
+      const data = await res.json();
+      setList((prev) => [...prev, data]);
+      setError(null);
+      return data;
+    } catch (err) {
+      console.error(err);
+      setError(err as Error);
+      throw err;
+    }
   }, [path, token]);
 
   const update = useCallback(async (item: T) => {
     if (!token) return;
-    await fetch(`${API}/${path}/${item.id}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(item),
-    });
-    setList((prev) => prev.map((x) => (x.id === item.id ? item : x)));
+    try {
+      const res = await fetch(`${API}/${path}/${item.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(item),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to update ${path}`);
+      }
+      setList((prev) => prev.map((x) => (x.id === item.id ? item : x)));
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError(err as Error);
+      throw err;
+    }
   }, [path, token]);
 
   const remove = useCallback(async (id: string) => {
     if (!token) return;
-    await fetch(`${API}/${path}/${id}`, {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    setList((prev) => prev.filter((x) => x.id !== id));
+    try {
+      const res = await fetch(`${API}/${path}/${id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to delete ${path}`);
+      }
+      setList((prev) => prev.filter((x) => x.id !== id));
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError(err as Error);
+      throw err;
+    }
   }, [path, token]);
 
-  return { list, setList, create, update, remove } as const;
+  return { list, setList, create, update, remove, error } as const;
 }


### PR DESCRIPTION
## Summary
- add AbortController and error state to remote data/list hooks
- wrap all fetch requests in try/catch and check `res.ok`
- skip state updates on failures and surface errors to callers

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint` *(fails: 18 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f935eafc8331aa26953ea87fccc0