### PR TITLE
Log error details in ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -5,7 +5,10 @@ type State = { hasError: boolean; error?: unknown };
 export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
   state: State = { hasError: false };
   static getDerivedStateFromError(error: unknown): State { return { hasError: true, error }; }
-  componentDidCatch(error: unknown) { console.error(error); }
+  componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
+    console.error(error, errorInfo);
+    // TODO: integrate remote logging/reporting service
+  }
   render() {
     if (this.state.hasError) {
       return (


### PR DESCRIPTION
## Summary
- log error details with `componentDidCatch` including `errorInfo`
- note placeholder for remote error logging

## Testing
- `npm test` (fails: Playwright Test did not expect test() to be called here)
- `npm run lint` (fails: multiple lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68b0f834997483319855d2205815d72b