### PR TITLE
Revoke object URL after CSV export

### DIFF
--- a/src/features/debts/CalendarExportButtons.tsx
+++ b/src/features/debts/CalendarExportButtons.tsx
@@ -37,7 +37,10 @@ export default function CalendarExportButtons({ debts, year, month }: { debts: D
     const header = ["Date","Name","Amount","Autopay","Notes"].join(",");
     const body = rows.map(r => [r.date, r.name, r.amount, r.autopay?"Yes":"No", (r.notes||"").replace(/"/g,'""')].map(x=>`"${x}"`).join(",")).join("\n");
     const blob = new Blob([header+"\n"+body], { type: "text/csv;charset=utf-8" });
-    const a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = `${title}.csv`; a.click();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = `${title}.csv`; a.click();
+    URL.revokeObjectURL(url); a.remove();
   }, [debts, year, month, title]);
 
   return (


### PR DESCRIPTION
## Summary
- free CSV object URL and remove temporary anchor after export

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called)*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f83415b88331bbd976628e4992b9