### PR TITLE
refactor: improve API health error typing

### DIFF
--- a/src/hooks/useApiHealth.ts
+++ b/src/hooks/useApiHealth.ts
@@ -12,7 +12,7 @@ export function useApiHealth(apiBase?: string, intervalMs = 15000) {
   const [health, setHealth] = useState<HealthStatus>({ status: 'unknown' });
 
   useEffect(() => {
-    let timer: any;
+    let timer: ReturnType<typeof setInterval> | undefined;
     const url = (apiBase || import.meta.env.VITE_API_URL || '').replace(/\/$/, '');
 
     async function ping() {
@@ -25,8 +25,9 @@ export function useApiHealth(apiBase?: string, intervalMs = 15000) {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         const json = await r.json();
         setHealth({ status: 'ok', version: json.version, uptime: json.uptime, node: json.node });
-      } catch (e: any) {
-        setHealth({ status: 'down', error: e?.message || 'fetch failed' });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'fetch failed';
+        setHealth({ status: 'down', error: message });
       }
     }
 


### PR DESCRIPTION
## Summary
- refactor API health hook timer to use ReturnType<typeof setInterval>
- handle caught errors with unknown type and safe message extraction

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f83244848331babec85fc02df4ca