### PR TITLE
refactor: use named useApiHealth import

### DIFF
--- a/src/components/system/ApiOkPill.tsx
+++ b/src/components/system/ApiOkPill.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import useApiHealth from "@/hooks/useApiHealth";
+import { useApiHealth } from "@/hooks/useApiHealth";
 
 export default function ApiOkPill() {
-  const { status, data } = useApiHealth?.() ?? { status: "checking" } as any;
-  if (status !== "ok") return null;
+  const health = useApiHealth();
+  if (health.status !== "ok") return null;
   return (
     <span className="ml-2 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs bg-emerald-100 text-emerald-800">
       <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-600" />
-      API OK{data?.version ? ` v${data.version}` : ''}
+      API OK{health.version ? ` v${health.version}` : ""}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- refactor ApiOkPill to use named useApiHealth hook
- simplify health check and version display

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called)*
- `npm run lint` *(fails: 17 errors, including no-var-requires and no-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f830cd108331bee9583be1e97500