### PR TITLE
Handle corrupt pending notification data

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,10 +15,15 @@ function rescheduleNotifications(reg: ServiceWorkerRegistration) {
         /* periodic sync may be unavailable */
       });
   }
-
-  const pending = JSON.parse(
-    localStorage.getItem('pending-notifications') || '[]'
-  );
+  let pending: unknown[] = [];
+  try {
+    pending = JSON.parse(
+      localStorage.getItem('pending-notifications') || '[]'
+    );
+  } catch (err) {
+    console.warn('Failed to parse pending notifications, clearing', err);
+    localStorage.removeItem('pending-notifications');
+  }
   for (const note of pending) {
     reg.active?.postMessage({ type: 'schedule', payload: note });
   }


### PR DESCRIPTION
## Summary
- guard against corrupt `pending-notifications` entries in `localStorage`
- clear invalid stored notifications and log a warning before rescheduling

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint` *(fails: 18 problems from existing code)*
- `npx eslint src/main.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b0f9d6a02083319bf9560745ed07f2