### PR TITLE
Fix dark theme text color for Input

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -8,6 +8,9 @@ export default function Input({
 }: { label?: string } & React.InputHTMLAttributes<HTMLInputElement>) {
   const uniqueId = React.useId();
   const inputId = id ?? uniqueId;
+  const baseClasses =
+    'px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent';
+
   return (
     <div className="flex flex-col">
       {label && (
@@ -20,7 +23,7 @@ export default function Input({
       )}
       <input
         id={inputId}
-        className={`px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent ${className}`}
+        className={`${baseClasses} ${className}`}
         {...props}
       />
     </div>

--- a/tests/input.spec.tsx
+++ b/tests/input.spec.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import Input from '../src/components/Input';
+
+describe('Input component', () => {
+  it('includes dark theme text color class', () => {
+    const html = renderToString(<Input />);
+    expect(html).toContain('dark:text-gray-100');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `dark:text-gray-100` in `Input` stays on a single line using a base class string
- add a unit test checking the Input component includes the dark theme text color class

## Testing
- `npm test tests/input.spec.tsx tests/persistence.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0f9d9642c8331b7ce6e102e34d42f