### PR TITLE
Collect promises during data import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,15 +267,17 @@ export default function App(){
     if (kind === 'ics') exportICS('chatpay-schedule.ics', bnpl, obligations);
   }
 
-  function handleImport(payload: ImportPayload) {
+  async function handleImport(payload: ImportPayload) {
     try {
-      payload.budgets.forEach((b) => addBudget(b));
+      const promises: Promise<unknown>[] = [];
+      payload.budgets.forEach((b) => promises.push(addBudget(b)));
       handleDebtsChange(payload.debts);
       setRecurring(payload.recurring);
       handleGoalsChange(payload.goals);
       if (payload.obligations) handleObligationsChange(payload.obligations);
-      if (payload.bnpl) payload.bnpl.forEach((p) => addBnplApi(p));
+      if (payload.bnpl) payload.bnpl.forEach((p) => promises.push(addBnplApi(p)));
       if (payload.transactions) handleTransactions(payload.transactions);
+      await Promise.all(promises);
       toast.success('Import complete');
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Summary
- await API calls during data import
- surface import errors via toast

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npm run lint` *(fails: ESLint issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f9d833648331aee9d2f8a9280b4d